### PR TITLE
Implement command status enums

### DIFF
--- a/src/main/java/com/commandbus/model/BatchStatus.java
+++ b/src/main/java/com/commandbus/model/BatchStatus.java
@@ -1,0 +1,37 @@
+package com.commandbus.model;
+
+/**
+ * Status of a batch in its lifecycle.
+ */
+public enum BatchStatus {
+    /** Batch created, no commands processed yet */
+    PENDING("PENDING"),
+
+    /** At least one command being processed */
+    IN_PROGRESS("IN_PROGRESS"),
+
+    /** All commands completed successfully */
+    COMPLETED("COMPLETED"),
+
+    /** All commands done, but some failed/canceled */
+    COMPLETED_WITH_FAILURES("COMPLETED_WITH_FAILURES");
+
+    private final String value;
+
+    BatchStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static BatchStatus fromValue(String value) {
+        for (BatchStatus status : values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown BatchStatus: " + value);
+    }
+}

--- a/src/main/java/com/commandbus/model/CommandStatus.java
+++ b/src/main/java/com/commandbus/model/CommandStatus.java
@@ -1,0 +1,43 @@
+package com.commandbus.model;
+
+/**
+ * Status of a command in its lifecycle.
+ */
+public enum CommandStatus {
+    /** Command queued, awaiting processing */
+    PENDING("PENDING"),
+
+    /** Currently being processed by a worker */
+    IN_PROGRESS("IN_PROGRESS"),
+
+    /** Successfully completed */
+    COMPLETED("COMPLETED"),
+
+    /** Failed (legacy status, use IN_TROUBLESHOOTING_QUEUE) */
+    FAILED("FAILED"),
+
+    /** Canceled by operator */
+    CANCELED("CANCELED"),
+
+    /** Failed after retries exhausted or permanent error */
+    IN_TROUBLESHOOTING_QUEUE("IN_TROUBLESHOOTING_QUEUE");
+
+    private final String value;
+
+    CommandStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static CommandStatus fromValue(String value) {
+        for (CommandStatus status : values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown CommandStatus: " + value);
+    }
+}

--- a/src/main/java/com/commandbus/model/ReplyOutcome.java
+++ b/src/main/java/com/commandbus/model/ReplyOutcome.java
@@ -1,0 +1,29 @@
+package com.commandbus.model;
+
+/**
+ * Outcome of command processing.
+ */
+public enum ReplyOutcome {
+    SUCCESS("SUCCESS"),
+    FAILED("FAILED"),
+    CANCELED("CANCELED");
+
+    private final String value;
+
+    ReplyOutcome(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static ReplyOutcome fromValue(String value) {
+        for (ReplyOutcome outcome : values()) {
+            if (outcome.value.equals(value)) {
+                return outcome;
+            }
+        }
+        throw new IllegalArgumentException("Unknown ReplyOutcome: " + value);
+    }
+}

--- a/src/test/java/com/commandbus/model/BatchStatusTest.java
+++ b/src/test/java/com/commandbus/model/BatchStatusTest.java
@@ -1,0 +1,49 @@
+package com.commandbus.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BatchStatusTest {
+
+    @Test
+    void shouldHaveAllExpectedValues() {
+        assertEquals(4, BatchStatus.values().length);
+        assertNotNull(BatchStatus.PENDING);
+        assertNotNull(BatchStatus.IN_PROGRESS);
+        assertNotNull(BatchStatus.COMPLETED);
+        assertNotNull(BatchStatus.COMPLETED_WITH_FAILURES);
+    }
+
+    @ParameterizedTest
+    @EnumSource(BatchStatus.class)
+    void getValueShouldReturnNonNullString(BatchStatus status) {
+        assertNotNull(status.getValue());
+        assertFalse(status.getValue().isEmpty());
+    }
+
+    @ParameterizedTest
+    @EnumSource(BatchStatus.class)
+    void fromValueShouldReturnCorrectEnum(BatchStatus status) {
+        assertEquals(status, BatchStatus.fromValue(status.getValue()));
+    }
+
+    @Test
+    void fromValueShouldThrowForUnknownValue() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> BatchStatus.fromValue("UNKNOWN")
+        );
+        assertTrue(exception.getMessage().contains("Unknown BatchStatus"));
+    }
+
+    @Test
+    void valuesShouldMatchDatabaseValues() {
+        assertEquals("PENDING", BatchStatus.PENDING.getValue());
+        assertEquals("IN_PROGRESS", BatchStatus.IN_PROGRESS.getValue());
+        assertEquals("COMPLETED", BatchStatus.COMPLETED.getValue());
+        assertEquals("COMPLETED_WITH_FAILURES", BatchStatus.COMPLETED_WITH_FAILURES.getValue());
+    }
+}

--- a/src/test/java/com/commandbus/model/CommandStatusTest.java
+++ b/src/test/java/com/commandbus/model/CommandStatusTest.java
@@ -1,0 +1,53 @@
+package com.commandbus.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandStatusTest {
+
+    @Test
+    void shouldHaveAllExpectedValues() {
+        assertEquals(6, CommandStatus.values().length);
+        assertNotNull(CommandStatus.PENDING);
+        assertNotNull(CommandStatus.IN_PROGRESS);
+        assertNotNull(CommandStatus.COMPLETED);
+        assertNotNull(CommandStatus.FAILED);
+        assertNotNull(CommandStatus.CANCELED);
+        assertNotNull(CommandStatus.IN_TROUBLESHOOTING_QUEUE);
+    }
+
+    @ParameterizedTest
+    @EnumSource(CommandStatus.class)
+    void getValueShouldReturnNonNullString(CommandStatus status) {
+        assertNotNull(status.getValue());
+        assertFalse(status.getValue().isEmpty());
+    }
+
+    @ParameterizedTest
+    @EnumSource(CommandStatus.class)
+    void fromValueShouldReturnCorrectEnum(CommandStatus status) {
+        assertEquals(status, CommandStatus.fromValue(status.getValue()));
+    }
+
+    @Test
+    void fromValueShouldThrowForUnknownValue() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> CommandStatus.fromValue("UNKNOWN")
+        );
+        assertTrue(exception.getMessage().contains("Unknown CommandStatus"));
+    }
+
+    @Test
+    void valuesShouldMatchDatabaseValues() {
+        assertEquals("PENDING", CommandStatus.PENDING.getValue());
+        assertEquals("IN_PROGRESS", CommandStatus.IN_PROGRESS.getValue());
+        assertEquals("COMPLETED", CommandStatus.COMPLETED.getValue());
+        assertEquals("FAILED", CommandStatus.FAILED.getValue());
+        assertEquals("CANCELED", CommandStatus.CANCELED.getValue());
+        assertEquals("IN_TROUBLESHOOTING_QUEUE", CommandStatus.IN_TROUBLESHOOTING_QUEUE.getValue());
+    }
+}

--- a/src/test/java/com/commandbus/model/ReplyOutcomeTest.java
+++ b/src/test/java/com/commandbus/model/ReplyOutcomeTest.java
@@ -1,0 +1,47 @@
+package com.commandbus.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReplyOutcomeTest {
+
+    @Test
+    void shouldHaveAllExpectedValues() {
+        assertEquals(3, ReplyOutcome.values().length);
+        assertNotNull(ReplyOutcome.SUCCESS);
+        assertNotNull(ReplyOutcome.FAILED);
+        assertNotNull(ReplyOutcome.CANCELED);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ReplyOutcome.class)
+    void getValueShouldReturnNonNullString(ReplyOutcome outcome) {
+        assertNotNull(outcome.getValue());
+        assertFalse(outcome.getValue().isEmpty());
+    }
+
+    @ParameterizedTest
+    @EnumSource(ReplyOutcome.class)
+    void fromValueShouldReturnCorrectEnum(ReplyOutcome outcome) {
+        assertEquals(outcome, ReplyOutcome.fromValue(outcome.getValue()));
+    }
+
+    @Test
+    void fromValueShouldThrowForUnknownValue() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> ReplyOutcome.fromValue("UNKNOWN")
+        );
+        assertTrue(exception.getMessage().contains("Unknown ReplyOutcome"));
+    }
+
+    @Test
+    void valuesShouldMatchDatabaseValues() {
+        assertEquals("SUCCESS", ReplyOutcome.SUCCESS.getValue());
+        assertEquals("FAILED", ReplyOutcome.FAILED.getValue());
+        assertEquals("CANCELED", ReplyOutcome.CANCELED.getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CommandStatus` enum with 6 states: PENDING, IN_PROGRESS, COMPLETED, FAILED, CANCELED, IN_TROUBLESHOOTING_QUEUE
- Add `BatchStatus` enum with 4 states: PENDING, IN_PROGRESS, COMPLETED, COMPLETED_WITH_FAILURES
- Add `ReplyOutcome` enum with 3 states: SUCCESS, FAILED, CANCELED
- Each enum includes `getValue()` for database serialization and `fromValue()` for deserialization

## Test plan
- [x] All enum values exist and are not null
- [x] `getValue()` returns non-empty strings
- [x] `fromValue()` round-trips correctly for all values
- [x] `fromValue()` throws IllegalArgumentException for unknown values
- [x] Values match expected database values
- [x] JaCoCo coverage > 80%

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)