### PR TITLE
Implement core domain records

### DIFF
--- a/src/main/java/com/commandbus/model/Command.java
+++ b/src/main/java/com/commandbus/model/Command.java
@@ -1,0 +1,52 @@
+package com.commandbus.model;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A command to be processed by a handler.
+ *
+ * <p>Commands are immutable value objects representing work to be done.
+ * They contain the command payload and metadata needed for routing and tracing.
+ *
+ * @param domain The domain this command belongs to (e.g., "payments")
+ * @param commandType The type of command (e.g., "DebitAccount")
+ * @param commandId Unique identifier for this command
+ * @param data The command payload as a map
+ * @param correlationId ID for tracing related commands (nullable)
+ * @param replyTo Queue to send reply to (nullable)
+ * @param createdAt When the command was created
+ */
+public record Command(
+    String domain,
+    String commandType,
+    UUID commandId,
+    Map<String, Object> data,
+    UUID correlationId,
+    String replyTo,
+    Instant createdAt
+) {
+    /**
+     * Creates a command with validation.
+     */
+    public Command {
+        if (domain == null || domain.isBlank()) {
+            throw new IllegalArgumentException("domain is required");
+        }
+        if (commandType == null || commandType.isBlank()) {
+            throw new IllegalArgumentException("commandType is required");
+        }
+        if (commandId == null) {
+            throw new IllegalArgumentException("commandId is required");
+        }
+        if (data == null) {
+            data = Map.of();
+        }
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+        // Make data immutable
+        data = Map.copyOf(data);
+    }
+}

--- a/src/main/java/com/commandbus/model/CommandMetadata.java
+++ b/src/main/java/com/commandbus/model/CommandMetadata.java
@@ -1,0 +1,91 @@
+package com.commandbus.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Metadata stored for each command.
+ *
+ * <p>Unlike Command (immutable), CommandMetadata is mutable and tracks
+ * the evolving state of command processing.
+ *
+ * @param domain The domain this command belongs to
+ * @param commandId Unique identifier
+ * @param commandType Type of command
+ * @param status Current status
+ * @param attempts Number of processing attempts
+ * @param maxAttempts Maximum allowed attempts
+ * @param msgId Current PGMQ message ID (nullable)
+ * @param correlationId Correlation ID for tracing (nullable)
+ * @param replyTo Reply queue (nullable)
+ * @param lastErrorType Type of last error (TRANSIENT/PERMANENT, nullable)
+ * @param lastErrorCode Application error code (nullable)
+ * @param lastErrorMessage Error message (nullable)
+ * @param createdAt Creation timestamp
+ * @param updatedAt Last update timestamp
+ * @param batchId Optional batch ID (nullable)
+ */
+public record CommandMetadata(
+    String domain,
+    UUID commandId,
+    String commandType,
+    CommandStatus status,
+    int attempts,
+    int maxAttempts,
+    Long msgId,
+    UUID correlationId,
+    String replyTo,
+    String lastErrorType,
+    String lastErrorCode,
+    String lastErrorMessage,
+    Instant createdAt,
+    Instant updatedAt,
+    UUID batchId
+) {
+    /**
+     * Creates a new command metadata with default values.
+     */
+    public static CommandMetadata create(
+            String domain,
+            UUID commandId,
+            String commandType,
+            int maxAttempts) {
+        var now = Instant.now();
+        return new CommandMetadata(
+            domain, commandId, commandType,
+            CommandStatus.PENDING,
+            0, maxAttempts,
+            null, null, null,
+            null, null, null,
+            now, now, null
+        );
+    }
+
+    /**
+     * Returns a copy with updated status.
+     */
+    public CommandMetadata withStatus(CommandStatus newStatus) {
+        return new CommandMetadata(
+            domain, commandId, commandType,
+            newStatus,
+            attempts, maxAttempts,
+            msgId, correlationId, replyTo,
+            lastErrorType, lastErrorCode, lastErrorMessage,
+            createdAt, Instant.now(), batchId
+        );
+    }
+
+    /**
+     * Returns a copy with error information.
+     */
+    public CommandMetadata withError(String errorType, String errorCode, String errorMessage) {
+        return new CommandMetadata(
+            domain, commandId, commandType,
+            status,
+            attempts, maxAttempts,
+            msgId, correlationId, replyTo,
+            errorType, errorCode, errorMessage,
+            createdAt, Instant.now(), batchId
+        );
+    }
+}

--- a/src/main/java/com/commandbus/model/HandlerContext.java
+++ b/src/main/java/com/commandbus/model/HandlerContext.java
@@ -1,0 +1,51 @@
+package com.commandbus.model;
+
+/**
+ * Context provided to command handlers during execution.
+ *
+ * <p>Provides access to command metadata and utilities like visibility
+ * timeout extension for long-running handlers.
+ *
+ * @param command The command being processed
+ * @param attempt Current attempt number (1-based)
+ * @param maxAttempts Maximum attempts before exhaustion
+ * @param msgId PGMQ message ID
+ * @param visibilityExtender Function to extend visibility timeout (nullable)
+ */
+public record HandlerContext(
+    Command command,
+    int attempt,
+    int maxAttempts,
+    long msgId,
+    VisibilityExtender visibilityExtender
+) {
+    /**
+     * Extend the visibility timeout for long-running operations.
+     *
+     * @param seconds Additional seconds to extend visibility
+     * @throws IllegalStateException if visibility extender is not available
+     */
+    public void extendVisibility(int seconds) {
+        if (visibilityExtender == null) {
+            throw new IllegalStateException("Visibility extender not available");
+        }
+        visibilityExtender.extend(seconds);
+    }
+
+    /**
+     * Check if this is the last retry attempt.
+     *
+     * @return true if no more retries after this attempt
+     */
+    public boolean isLastAttempt() {
+        return attempt >= maxAttempts;
+    }
+
+    /**
+     * Functional interface for extending message visibility.
+     */
+    @FunctionalInterface
+    public interface VisibilityExtender {
+        void extend(int seconds);
+    }
+}

--- a/src/test/java/com/commandbus/model/CommandMetadataTest.java
+++ b/src/test/java/com/commandbus/model/CommandMetadataTest.java
@@ -1,0 +1,214 @@
+package com.commandbus.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandMetadataTest {
+
+    @Test
+    void shouldCreateWithDefaults() {
+        UUID commandId = UUID.randomUUID();
+        Instant before = Instant.now();
+
+        CommandMetadata metadata = CommandMetadata.create("payments", commandId, "DebitAccount", 5);
+
+        Instant after = Instant.now();
+        assertEquals("payments", metadata.domain());
+        assertEquals(commandId, metadata.commandId());
+        assertEquals("DebitAccount", metadata.commandType());
+        assertEquals(CommandStatus.PENDING, metadata.status());
+        assertEquals(0, metadata.attempts());
+        assertEquals(5, metadata.maxAttempts());
+        assertNull(metadata.msgId());
+        assertNull(metadata.correlationId());
+        assertNull(metadata.replyTo());
+        assertNull(metadata.lastErrorType());
+        assertNull(metadata.lastErrorCode());
+        assertNull(metadata.lastErrorMessage());
+        assertNotNull(metadata.createdAt());
+        assertNotNull(metadata.updatedAt());
+        assertFalse(metadata.createdAt().isBefore(before));
+        assertFalse(metadata.createdAt().isAfter(after));
+        assertNull(metadata.batchId());
+    }
+
+    @Test
+    void shouldCreateWithAllFields() {
+        UUID commandId = UUID.randomUUID();
+        UUID correlationId = UUID.randomUUID();
+        UUID batchId = UUID.randomUUID();
+        Instant createdAt = Instant.now().minusSeconds(60);
+        Instant updatedAt = Instant.now();
+
+        CommandMetadata metadata = new CommandMetadata(
+            "payments",
+            commandId,
+            "DebitAccount",
+            CommandStatus.IN_PROGRESS,
+            2,
+            5,
+            12345L,
+            correlationId,
+            "reply-queue",
+            "TRANSIENT",
+            "TIMEOUT",
+            "Connection timeout",
+            createdAt,
+            updatedAt,
+            batchId
+        );
+
+        assertEquals("payments", metadata.domain());
+        assertEquals(commandId, metadata.commandId());
+        assertEquals("DebitAccount", metadata.commandType());
+        assertEquals(CommandStatus.IN_PROGRESS, metadata.status());
+        assertEquals(2, metadata.attempts());
+        assertEquals(5, metadata.maxAttempts());
+        assertEquals(12345L, metadata.msgId());
+        assertEquals(correlationId, metadata.correlationId());
+        assertEquals("reply-queue", metadata.replyTo());
+        assertEquals("TRANSIENT", metadata.lastErrorType());
+        assertEquals("TIMEOUT", metadata.lastErrorCode());
+        assertEquals("Connection timeout", metadata.lastErrorMessage());
+        assertEquals(createdAt, metadata.createdAt());
+        assertEquals(updatedAt, metadata.updatedAt());
+        assertEquals(batchId, metadata.batchId());
+    }
+
+    @Test
+    void shouldUpdateStatus() {
+        UUID commandId = UUID.randomUUID();
+        CommandMetadata original = CommandMetadata.create("payments", commandId, "DebitAccount", 5);
+        Instant originalCreatedAt = original.createdAt();
+
+        CommandMetadata updated = original.withStatus(CommandStatus.IN_PROGRESS);
+
+        // Original should be unchanged
+        assertEquals(CommandStatus.PENDING, original.status());
+
+        // Updated should have new status
+        assertEquals(CommandStatus.IN_PROGRESS, updated.status());
+        assertEquals(originalCreatedAt, updated.createdAt());
+        assertTrue(updated.updatedAt().isAfter(originalCreatedAt) ||
+                   updated.updatedAt().equals(originalCreatedAt));
+
+        // Other fields should be preserved
+        assertEquals(original.domain(), updated.domain());
+        assertEquals(original.commandId(), updated.commandId());
+        assertEquals(original.commandType(), updated.commandType());
+        assertEquals(original.attempts(), updated.attempts());
+        assertEquals(original.maxAttempts(), updated.maxAttempts());
+    }
+
+    @Test
+    void shouldUpdateError() {
+        UUID commandId = UUID.randomUUID();
+        CommandMetadata original = CommandMetadata.create("payments", commandId, "DebitAccount", 5);
+        Instant originalCreatedAt = original.createdAt();
+
+        CommandMetadata updated = original.withError("TRANSIENT", "TIMEOUT", "Connection timeout");
+
+        // Original should be unchanged
+        assertNull(original.lastErrorType());
+        assertNull(original.lastErrorCode());
+        assertNull(original.lastErrorMessage());
+
+        // Updated should have error info
+        assertEquals("TRANSIENT", updated.lastErrorType());
+        assertEquals("TIMEOUT", updated.lastErrorCode());
+        assertEquals("Connection timeout", updated.lastErrorMessage());
+        assertEquals(originalCreatedAt, updated.createdAt());
+        assertTrue(updated.updatedAt().isAfter(originalCreatedAt) ||
+                   updated.updatedAt().equals(originalCreatedAt));
+
+        // Other fields should be preserved
+        assertEquals(original.domain(), updated.domain());
+        assertEquals(original.commandId(), updated.commandId());
+        assertEquals(original.status(), updated.status());
+    }
+
+    @Test
+    void shouldSupportEqualsAndHashCode() {
+        UUID commandId = UUID.randomUUID();
+        Instant now = Instant.now();
+
+        CommandMetadata metadata1 = new CommandMetadata(
+            "payments", commandId, "DebitAccount", CommandStatus.PENDING,
+            0, 5, null, null, null, null, null, null, now, now, null
+        );
+        CommandMetadata metadata2 = new CommandMetadata(
+            "payments", commandId, "DebitAccount", CommandStatus.PENDING,
+            0, 5, null, null, null, null, null, null, now, now, null
+        );
+        CommandMetadata metadata3 = new CommandMetadata(
+            "orders", commandId, "DebitAccount", CommandStatus.PENDING,
+            0, 5, null, null, null, null, null, null, now, now, null
+        );
+
+        assertEquals(metadata1, metadata2);
+        assertEquals(metadata1.hashCode(), metadata2.hashCode());
+        assertNotEquals(metadata1, metadata3);
+    }
+
+    @Test
+    void withStatusShouldPreserveAllOtherFields() {
+        UUID commandId = UUID.randomUUID();
+        UUID correlationId = UUID.randomUUID();
+        UUID batchId = UUID.randomUUID();
+        Instant createdAt = Instant.now().minusSeconds(60);
+
+        CommandMetadata original = new CommandMetadata(
+            "payments", commandId, "DebitAccount", CommandStatus.PENDING,
+            2, 5, 12345L, correlationId, "reply-queue",
+            "TRANSIENT", "TIMEOUT", "Error msg", createdAt, createdAt, batchId
+        );
+
+        CommandMetadata updated = original.withStatus(CommandStatus.IN_PROGRESS);
+
+        assertEquals(original.domain(), updated.domain());
+        assertEquals(original.commandId(), updated.commandId());
+        assertEquals(original.commandType(), updated.commandType());
+        assertEquals(original.attempts(), updated.attempts());
+        assertEquals(original.maxAttempts(), updated.maxAttempts());
+        assertEquals(original.msgId(), updated.msgId());
+        assertEquals(original.correlationId(), updated.correlationId());
+        assertEquals(original.replyTo(), updated.replyTo());
+        assertEquals(original.lastErrorType(), updated.lastErrorType());
+        assertEquals(original.lastErrorCode(), updated.lastErrorCode());
+        assertEquals(original.lastErrorMessage(), updated.lastErrorMessage());
+        assertEquals(original.createdAt(), updated.createdAt());
+        assertEquals(original.batchId(), updated.batchId());
+    }
+
+    @Test
+    void withErrorShouldPreserveAllOtherFields() {
+        UUID commandId = UUID.randomUUID();
+        UUID correlationId = UUID.randomUUID();
+        UUID batchId = UUID.randomUUID();
+        Instant createdAt = Instant.now().minusSeconds(60);
+
+        CommandMetadata original = new CommandMetadata(
+            "payments", commandId, "DebitAccount", CommandStatus.IN_PROGRESS,
+            2, 5, 12345L, correlationId, "reply-queue",
+            null, null, null, createdAt, createdAt, batchId
+        );
+
+        CommandMetadata updated = original.withError("PERMANENT", "INVALID", "Invalid data");
+
+        assertEquals(original.domain(), updated.domain());
+        assertEquals(original.commandId(), updated.commandId());
+        assertEquals(original.commandType(), updated.commandType());
+        assertEquals(original.status(), updated.status());
+        assertEquals(original.attempts(), updated.attempts());
+        assertEquals(original.maxAttempts(), updated.maxAttempts());
+        assertEquals(original.msgId(), updated.msgId());
+        assertEquals(original.correlationId(), updated.correlationId());
+        assertEquals(original.replyTo(), updated.replyTo());
+        assertEquals(original.createdAt(), updated.createdAt());
+        assertEquals(original.batchId(), updated.batchId());
+    }
+}

--- a/src/test/java/com/commandbus/model/CommandTest.java
+++ b/src/test/java/com/commandbus/model/CommandTest.java
@@ -1,0 +1,176 @@
+package com.commandbus.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandTest {
+
+    @Test
+    void shouldCreateCommandWithAllFields() {
+        UUID commandId = UUID.randomUUID();
+        UUID correlationId = UUID.randomUUID();
+        Instant createdAt = Instant.now();
+        Map<String, Object> data = Map.of("key", "value");
+
+        Command command = new Command(
+            "payments",
+            "DebitAccount",
+            commandId,
+            data,
+            correlationId,
+            "reply-queue",
+            createdAt
+        );
+
+        assertEquals("payments", command.domain());
+        assertEquals("DebitAccount", command.commandType());
+        assertEquals(commandId, command.commandId());
+        assertEquals(Map.of("key", "value"), command.data());
+        assertEquals(correlationId, command.correlationId());
+        assertEquals("reply-queue", command.replyTo());
+        assertEquals(createdAt, command.createdAt());
+    }
+
+    @Test
+    void shouldCreateCommandWithNullOptionalFields() {
+        UUID commandId = UUID.randomUUID();
+        Instant createdAt = Instant.now();
+
+        Command command = new Command(
+            "payments",
+            "DebitAccount",
+            commandId,
+            null,
+            null,
+            null,
+            createdAt
+        );
+
+        assertEquals("payments", command.domain());
+        assertEquals("DebitAccount", command.commandType());
+        assertEquals(commandId, command.commandId());
+        assertEquals(Map.of(), command.data());
+        assertNull(command.correlationId());
+        assertNull(command.replyTo());
+    }
+
+    @Test
+    void shouldDefaultCreatedAtToNow() {
+        UUID commandId = UUID.randomUUID();
+        Instant before = Instant.now();
+
+        Command command = new Command(
+            "payments",
+            "DebitAccount",
+            commandId,
+            null,
+            null,
+            null,
+            null
+        );
+
+        Instant after = Instant.now();
+        assertNotNull(command.createdAt());
+        assertFalse(command.createdAt().isBefore(before));
+        assertFalse(command.createdAt().isAfter(after));
+    }
+
+    @Test
+    void shouldMakeDataImmutable() {
+        UUID commandId = UUID.randomUUID();
+        Map<String, Object> mutableData = new HashMap<>();
+        mutableData.put("key", "value");
+
+        Command command = new Command(
+            "payments",
+            "DebitAccount",
+            commandId,
+            mutableData,
+            null,
+            null,
+            Instant.now()
+        );
+
+        // Original map modification should not affect command
+        mutableData.put("another", "entry");
+        assertEquals(1, command.data().size());
+
+        // Command data should be immutable
+        assertThrows(UnsupportedOperationException.class,
+            () -> command.data().put("new", "entry"));
+    }
+
+    @Test
+    void shouldThrowWhenDomainIsNull() {
+        UUID commandId = UUID.randomUUID();
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new Command(null, "DebitAccount", commandId, null, null, null, null)
+        );
+        assertEquals("domain is required", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowWhenDomainIsBlank() {
+        UUID commandId = UUID.randomUUID();
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new Command("  ", "DebitAccount", commandId, null, null, null, null)
+        );
+        assertEquals("domain is required", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowWhenCommandTypeIsNull() {
+        UUID commandId = UUID.randomUUID();
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new Command("payments", null, commandId, null, null, null, null)
+        );
+        assertEquals("commandType is required", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowWhenCommandTypeIsBlank() {
+        UUID commandId = UUID.randomUUID();
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new Command("payments", "", commandId, null, null, null, null)
+        );
+        assertEquals("commandType is required", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowWhenCommandIdIsNull() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new Command("payments", "DebitAccount", null, null, null, null, null)
+        );
+        assertEquals("commandId is required", exception.getMessage());
+    }
+
+    @Test
+    void shouldSupportEqualsAndHashCode() {
+        UUID commandId = UUID.randomUUID();
+        Instant createdAt = Instant.now();
+        Map<String, Object> data = Map.of("key", "value");
+
+        Command command1 = new Command("payments", "DebitAccount", commandId, data, null, null, createdAt);
+        Command command2 = new Command("payments", "DebitAccount", commandId, data, null, null, createdAt);
+        Command command3 = new Command("orders", "DebitAccount", commandId, data, null, null, createdAt);
+
+        assertEquals(command1, command2);
+        assertEquals(command1.hashCode(), command2.hashCode());
+        assertNotEquals(command1, command3);
+    }
+}

--- a/src/test/java/com/commandbus/model/HandlerContextTest.java
+++ b/src/test/java/com/commandbus/model/HandlerContextTest.java
@@ -1,0 +1,100 @@
+package com.commandbus.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HandlerContextTest {
+
+    private Command createTestCommand() {
+        return new Command(
+            "payments",
+            "DebitAccount",
+            UUID.randomUUID(),
+            Map.of("amount", 100),
+            null,
+            null,
+            Instant.now()
+        );
+    }
+
+    @Test
+    void shouldCreateHandlerContext() {
+        Command command = createTestCommand();
+        HandlerContext.VisibilityExtender extender = seconds -> {};
+
+        HandlerContext context = new HandlerContext(command, 1, 5, 12345L, extender);
+
+        assertEquals(command, context.command());
+        assertEquals(1, context.attempt());
+        assertEquals(5, context.maxAttempts());
+        assertEquals(12345L, context.msgId());
+        assertNotNull(context.visibilityExtender());
+    }
+
+    @Test
+    void shouldCreateHandlerContextWithNullExtender() {
+        Command command = createTestCommand();
+
+        HandlerContext context = new HandlerContext(command, 1, 5, 12345L, null);
+
+        assertNull(context.visibilityExtender());
+    }
+
+    @Test
+    void shouldExtendVisibility() {
+        Command command = createTestCommand();
+        AtomicInteger extendedSeconds = new AtomicInteger(0);
+        HandlerContext.VisibilityExtender extender = extendedSeconds::set;
+
+        HandlerContext context = new HandlerContext(command, 1, 5, 12345L, extender);
+        context.extendVisibility(30);
+
+        assertEquals(30, extendedSeconds.get());
+    }
+
+    @Test
+    void shouldThrowWhenExtendingWithNullExtender() {
+        Command command = createTestCommand();
+        HandlerContext context = new HandlerContext(command, 1, 5, 12345L, null);
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> context.extendVisibility(30)
+        );
+        assertEquals("Visibility extender not available", exception.getMessage());
+    }
+
+    @Test
+    void shouldIdentifyLastAttempt() {
+        Command command = createTestCommand();
+
+        HandlerContext lastAttempt = new HandlerContext(command, 5, 5, 12345L, null);
+        HandlerContext beyondMax = new HandlerContext(command, 6, 5, 12345L, null);
+        HandlerContext notLast = new HandlerContext(command, 3, 5, 12345L, null);
+        HandlerContext firstAttempt = new HandlerContext(command, 1, 5, 12345L, null);
+
+        assertTrue(lastAttempt.isLastAttempt());
+        assertTrue(beyondMax.isLastAttempt());
+        assertFalse(notLast.isLastAttempt());
+        assertFalse(firstAttempt.isLastAttempt());
+    }
+
+    @Test
+    void shouldSupportEqualsAndHashCode() {
+        Command command = createTestCommand();
+
+        HandlerContext context1 = new HandlerContext(command, 1, 5, 12345L, null);
+        HandlerContext context2 = new HandlerContext(command, 1, 5, 12345L, null);
+        HandlerContext context3 = new HandlerContext(command, 2, 5, 12345L, null);
+
+        assertEquals(context1, context2);
+        assertEquals(context1.hashCode(), context2.hashCode());
+        assertNotEquals(context1, context3);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Command` record - immutable command with validation for required fields
- Add `CommandMetadata` record - tracks command processing state with factory and transition methods
- Add `HandlerContext` record - provides handler execution context with visibility extension

## Details
- `Command` validates domain, commandType, and commandId are non-null/blank
- `Command` makes data map immutable and defaults createdAt to now
- `CommandMetadata.create()` factory method for creating with default values
- `CommandMetadata.withStatus()` and `withError()` for state transitions
- `HandlerContext.extendVisibility()` delegates to VisibilityExtender
- `HandlerContext.isLastAttempt()` checks if current attempt is final

## Test plan
- [x] Command validates required fields throw on null/blank
- [x] Command defaults optional fields correctly
- [x] Command data is immutable
- [x] CommandMetadata factory creates with defaults
- [x] CommandMetadata state transitions preserve other fields
- [x] HandlerContext visibility extension works
- [x] HandlerContext isLastAttempt logic correct
- [x] JaCoCo coverage > 80%

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)