### PR TITLE
Implement exception hierarchy

### DIFF
--- a/src/main/java/com/commandbus/exception/BatchNotFoundException.java
+++ b/src/main/java/com/commandbus/exception/BatchNotFoundException.java
@@ -1,0 +1,24 @@
+package com.commandbus.exception;
+
+/**
+ * Thrown when a batch cannot be found.
+ */
+public class BatchNotFoundException extends CommandBusException {
+
+    private final String domain;
+    private final String batchId;
+
+    public BatchNotFoundException(String domain, String batchId) {
+        super("Batch " + batchId + " not found in domain " + domain);
+        this.domain = domain;
+        this.batchId = batchId;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public String getBatchId() {
+        return batchId;
+    }
+}

--- a/src/main/java/com/commandbus/exception/CommandBusException.java
+++ b/src/main/java/com/commandbus/exception/CommandBusException.java
@@ -1,0 +1,15 @@
+package com.commandbus.exception;
+
+/**
+ * Base exception for all Command Bus errors.
+ */
+public class CommandBusException extends RuntimeException {
+
+    public CommandBusException(String message) {
+        super(message);
+    }
+
+    public CommandBusException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/commandbus/exception/CommandNotFoundException.java
+++ b/src/main/java/com/commandbus/exception/CommandNotFoundException.java
@@ -1,0 +1,24 @@
+package com.commandbus.exception;
+
+/**
+ * Thrown when a command cannot be found.
+ */
+public class CommandNotFoundException extends CommandBusException {
+
+    private final String domain;
+    private final String commandId;
+
+    public CommandNotFoundException(String domain, String commandId) {
+        super("Command " + commandId + " not found in domain " + domain);
+        this.domain = domain;
+        this.commandId = commandId;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public String getCommandId() {
+        return commandId;
+    }
+}

--- a/src/main/java/com/commandbus/exception/DuplicateCommandException.java
+++ b/src/main/java/com/commandbus/exception/DuplicateCommandException.java
@@ -1,0 +1,24 @@
+package com.commandbus.exception;
+
+/**
+ * Thrown when attempting to send a command with a duplicate command_id.
+ */
+public class DuplicateCommandException extends CommandBusException {
+
+    private final String domain;
+    private final String commandId;
+
+    public DuplicateCommandException(String domain, String commandId) {
+        super("Duplicate command_id " + commandId + " in domain " + domain);
+        this.domain = domain;
+        this.commandId = commandId;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public String getCommandId() {
+        return commandId;
+    }
+}

--- a/src/main/java/com/commandbus/exception/HandlerAlreadyRegisteredException.java
+++ b/src/main/java/com/commandbus/exception/HandlerAlreadyRegisteredException.java
@@ -1,0 +1,24 @@
+package com.commandbus.exception;
+
+/**
+ * Thrown when attempting to register a handler for a command type that already has one.
+ */
+public class HandlerAlreadyRegisteredException extends CommandBusException {
+
+    private final String domain;
+    private final String commandType;
+
+    public HandlerAlreadyRegisteredException(String domain, String commandType) {
+        super("Handler already registered for " + domain + "." + commandType);
+        this.domain = domain;
+        this.commandType = commandType;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public String getCommandType() {
+        return commandType;
+    }
+}

--- a/src/main/java/com/commandbus/exception/HandlerNotFoundException.java
+++ b/src/main/java/com/commandbus/exception/HandlerNotFoundException.java
@@ -1,0 +1,24 @@
+package com.commandbus.exception;
+
+/**
+ * Thrown when no handler is registered for a command type.
+ */
+public class HandlerNotFoundException extends CommandBusException {
+
+    private final String domain;
+    private final String commandType;
+
+    public HandlerNotFoundException(String domain, String commandType) {
+        super("No handler registered for " + domain + "." + commandType);
+        this.domain = domain;
+        this.commandType = commandType;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public String getCommandType() {
+        return commandType;
+    }
+}

--- a/src/main/java/com/commandbus/exception/InvalidOperationException.java
+++ b/src/main/java/com/commandbus/exception/InvalidOperationException.java
@@ -1,0 +1,11 @@
+package com.commandbus.exception;
+
+/**
+ * Thrown when an invalid state transition or operation is attempted.
+ */
+public class InvalidOperationException extends CommandBusException {
+
+    public InvalidOperationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/commandbus/exception/PermanentCommandException.java
+++ b/src/main/java/com/commandbus/exception/PermanentCommandException.java
@@ -1,0 +1,39 @@
+package com.commandbus.exception;
+
+import java.util.Map;
+
+/**
+ * Raised for non-retryable failures (validation, business rule violations).
+ *
+ * <p>When a handler throws this exception, the command immediately moves
+ * to the troubleshooting queue without retrying.
+ */
+public class PermanentCommandException extends CommandBusException {
+
+    private final String code;
+    private final String errorMessage;
+    private final Map<String, Object> details;
+
+    public PermanentCommandException(String code, String message) {
+        this(code, message, Map.of());
+    }
+
+    public PermanentCommandException(String code, String message, Map<String, Object> details) {
+        super("[" + code + "] " + message);
+        this.code = code;
+        this.errorMessage = message;
+        this.details = details != null ? Map.copyOf(details) : Map.of();
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Map<String, Object> getDetails() {
+        return details;
+    }
+}

--- a/src/main/java/com/commandbus/exception/TransientCommandException.java
+++ b/src/main/java/com/commandbus/exception/TransientCommandException.java
@@ -1,0 +1,39 @@
+package com.commandbus.exception;
+
+import java.util.Map;
+
+/**
+ * Raised for retryable failures (network, timeout, temporary unavailability).
+ *
+ * <p>When a handler throws this exception, the command will be retried
+ * according to the retry policy. After max attempts, it moves to TSQ.
+ */
+public class TransientCommandException extends CommandBusException {
+
+    private final String code;
+    private final String errorMessage;
+    private final Map<String, Object> details;
+
+    public TransientCommandException(String code, String message) {
+        this(code, message, Map.of());
+    }
+
+    public TransientCommandException(String code, String message, Map<String, Object> details) {
+        super("[" + code + "] " + message);
+        this.code = code;
+        this.errorMessage = message;
+        this.details = details != null ? Map.copyOf(details) : Map.of();
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Map<String, Object> getDetails() {
+        return details;
+    }
+}

--- a/src/test/java/com/commandbus/exception/ExceptionTest.java
+++ b/src/test/java/com/commandbus/exception/ExceptionTest.java
@@ -1,0 +1,252 @@
+package com.commandbus.exception;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExceptionTest {
+
+    @Nested
+    class CommandBusExceptionTest {
+
+        @Test
+        void shouldCreateWithMessage() {
+            CommandBusException exception = new CommandBusException("Test message");
+            assertEquals("Test message", exception.getMessage());
+            assertNull(exception.getCause());
+        }
+
+        @Test
+        void shouldCreateWithMessageAndCause() {
+            RuntimeException cause = new RuntimeException("Original error");
+            CommandBusException exception = new CommandBusException("Test message", cause);
+            assertEquals("Test message", exception.getMessage());
+            assertEquals(cause, exception.getCause());
+        }
+
+        @Test
+        void shouldBeRuntimeException() {
+            CommandBusException exception = new CommandBusException("Test");
+            assertInstanceOf(RuntimeException.class, exception);
+        }
+    }
+
+    @Nested
+    class TransientCommandExceptionTest {
+
+        @Test
+        void shouldCreateWithCodeAndMessage() {
+            TransientCommandException exception = new TransientCommandException("TIMEOUT", "Connection timed out");
+
+            assertEquals("TIMEOUT", exception.getCode());
+            assertEquals("Connection timed out", exception.getErrorMessage());
+            assertEquals("[TIMEOUT] Connection timed out", exception.getMessage());
+            assertEquals(Map.of(), exception.getDetails());
+        }
+
+        @Test
+        void shouldCreateWithDetails() {
+            Map<String, Object> details = Map.of("retryAfter", 30, "endpoint", "api.example.com");
+            TransientCommandException exception = new TransientCommandException("TIMEOUT", "Connection timed out", details);
+
+            assertEquals("TIMEOUT", exception.getCode());
+            assertEquals("Connection timed out", exception.getErrorMessage());
+            assertEquals(details, exception.getDetails());
+        }
+
+        @Test
+        void shouldMakeDetailsImmutable() {
+            Map<String, Object> mutableDetails = new HashMap<>();
+            mutableDetails.put("key", "value");
+
+            TransientCommandException exception = new TransientCommandException("CODE", "msg", mutableDetails);
+
+            // Original map modification should not affect exception
+            mutableDetails.put("another", "entry");
+            assertEquals(1, exception.getDetails().size());
+
+            // Exception details should be immutable
+            assertThrows(UnsupportedOperationException.class,
+                () -> exception.getDetails().put("new", "entry"));
+        }
+
+        @Test
+        void shouldHandleNullDetails() {
+            TransientCommandException exception = new TransientCommandException("CODE", "msg", null);
+            assertEquals(Map.of(), exception.getDetails());
+        }
+
+        @Test
+        void shouldBeCommandBusException() {
+            TransientCommandException exception = new TransientCommandException("CODE", "msg");
+            assertInstanceOf(CommandBusException.class, exception);
+        }
+    }
+
+    @Nested
+    class PermanentCommandExceptionTest {
+
+        @Test
+        void shouldCreateWithCodeAndMessage() {
+            PermanentCommandException exception = new PermanentCommandException("INVALID", "Invalid account");
+
+            assertEquals("INVALID", exception.getCode());
+            assertEquals("Invalid account", exception.getErrorMessage());
+            assertEquals("[INVALID] Invalid account", exception.getMessage());
+            assertEquals(Map.of(), exception.getDetails());
+        }
+
+        @Test
+        void shouldCreateWithDetails() {
+            Map<String, Object> details = Map.of("field", "accountId", "reason", "not found");
+            PermanentCommandException exception = new PermanentCommandException("INVALID", "Invalid account", details);
+
+            assertEquals("INVALID", exception.getCode());
+            assertEquals("Invalid account", exception.getErrorMessage());
+            assertEquals(details, exception.getDetails());
+        }
+
+        @Test
+        void shouldMakeDetailsImmutable() {
+            Map<String, Object> mutableDetails = new HashMap<>();
+            mutableDetails.put("key", "value");
+
+            PermanentCommandException exception = new PermanentCommandException("CODE", "msg", mutableDetails);
+
+            // Original map modification should not affect exception
+            mutableDetails.put("another", "entry");
+            assertEquals(1, exception.getDetails().size());
+
+            // Exception details should be immutable
+            assertThrows(UnsupportedOperationException.class,
+                () -> exception.getDetails().put("new", "entry"));
+        }
+
+        @Test
+        void shouldHandleNullDetails() {
+            PermanentCommandException exception = new PermanentCommandException("CODE", "msg", null);
+            assertEquals(Map.of(), exception.getDetails());
+        }
+
+        @Test
+        void shouldBeCommandBusException() {
+            PermanentCommandException exception = new PermanentCommandException("CODE", "msg");
+            assertInstanceOf(CommandBusException.class, exception);
+        }
+    }
+
+    @Nested
+    class HandlerNotFoundExceptionTest {
+
+        @Test
+        void shouldCreateWithDomainAndCommandType() {
+            HandlerNotFoundException exception = new HandlerNotFoundException("payments", "DebitAccount");
+
+            assertEquals("payments", exception.getDomain());
+            assertEquals("DebitAccount", exception.getCommandType());
+            assertEquals("No handler registered for payments.DebitAccount", exception.getMessage());
+        }
+
+        @Test
+        void shouldBeCommandBusException() {
+            HandlerNotFoundException exception = new HandlerNotFoundException("domain", "type");
+            assertInstanceOf(CommandBusException.class, exception);
+        }
+    }
+
+    @Nested
+    class HandlerAlreadyRegisteredExceptionTest {
+
+        @Test
+        void shouldCreateWithDomainAndCommandType() {
+            HandlerAlreadyRegisteredException exception = new HandlerAlreadyRegisteredException("payments", "DebitAccount");
+
+            assertEquals("payments", exception.getDomain());
+            assertEquals("DebitAccount", exception.getCommandType());
+            assertEquals("Handler already registered for payments.DebitAccount", exception.getMessage());
+        }
+
+        @Test
+        void shouldBeCommandBusException() {
+            HandlerAlreadyRegisteredException exception = new HandlerAlreadyRegisteredException("domain", "type");
+            assertInstanceOf(CommandBusException.class, exception);
+        }
+    }
+
+    @Nested
+    class DuplicateCommandExceptionTest {
+
+        @Test
+        void shouldCreateWithDomainAndCommandId() {
+            DuplicateCommandException exception = new DuplicateCommandException("payments", "cmd-123");
+
+            assertEquals("payments", exception.getDomain());
+            assertEquals("cmd-123", exception.getCommandId());
+            assertEquals("Duplicate command_id cmd-123 in domain payments", exception.getMessage());
+        }
+
+        @Test
+        void shouldBeCommandBusException() {
+            DuplicateCommandException exception = new DuplicateCommandException("domain", "id");
+            assertInstanceOf(CommandBusException.class, exception);
+        }
+    }
+
+    @Nested
+    class CommandNotFoundExceptionTest {
+
+        @Test
+        void shouldCreateWithDomainAndCommandId() {
+            CommandNotFoundException exception = new CommandNotFoundException("payments", "cmd-456");
+
+            assertEquals("payments", exception.getDomain());
+            assertEquals("cmd-456", exception.getCommandId());
+            assertEquals("Command cmd-456 not found in domain payments", exception.getMessage());
+        }
+
+        @Test
+        void shouldBeCommandBusException() {
+            CommandNotFoundException exception = new CommandNotFoundException("domain", "id");
+            assertInstanceOf(CommandBusException.class, exception);
+        }
+    }
+
+    @Nested
+    class BatchNotFoundExceptionTest {
+
+        @Test
+        void shouldCreateWithDomainAndBatchId() {
+            BatchNotFoundException exception = new BatchNotFoundException("payments", "batch-789");
+
+            assertEquals("payments", exception.getDomain());
+            assertEquals("batch-789", exception.getBatchId());
+            assertEquals("Batch batch-789 not found in domain payments", exception.getMessage());
+        }
+
+        @Test
+        void shouldBeCommandBusException() {
+            BatchNotFoundException exception = new BatchNotFoundException("domain", "id");
+            assertInstanceOf(CommandBusException.class, exception);
+        }
+    }
+
+    @Nested
+    class InvalidOperationExceptionTest {
+
+        @Test
+        void shouldCreateWithMessage() {
+            InvalidOperationException exception = new InvalidOperationException("Cannot cancel completed command");
+            assertEquals("Cannot cancel completed command", exception.getMessage());
+        }
+
+        @Test
+        void shouldBeCommandBusException() {
+            InvalidOperationException exception = new InvalidOperationException("msg");
+            assertInstanceOf(CommandBusException.class, exception);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CommandBusException` - base exception for all command bus errors
- Add `TransientCommandException` - retryable failures (network, timeout, temporary unavailability)
- Add `PermanentCommandException` - non-retryable failures (validation, business rules)
- Add domain-specific exceptions: `HandlerNotFoundException`, `HandlerAlreadyRegisteredException`, `DuplicateCommandException`, `CommandNotFoundException`, `BatchNotFoundException`, `InvalidOperationException`

## Details
- Transient/Permanent exceptions include code, message, and optional details map
- Details maps are made immutable to prevent modification after creation
- All exceptions extend CommandBusException (which extends RuntimeException)
- Exception messages are formatted as `[CODE] message` for easy parsing

## Test plan
- [x] CommandBusException creates with message and cause
- [x] TransientCommandException provides code, message, details via getters
- [x] PermanentCommandException provides code, message, details via getters
- [x] Details maps are immutable
- [x] Null details default to empty map
- [x] All domain exceptions have correct messages
- [x] All exceptions extend CommandBusException
- [x] JaCoCo coverage > 80%

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)