### PR TITLE
Implement PgmqClient interface and QueueNames utility

### DIFF
--- a/src/main/java/com/commandbus/model/PgmqMessage.java
+++ b/src/main/java/com/commandbus/model/PgmqMessage.java
@@ -1,0 +1,30 @@
+package com.commandbus.model;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * A message from a PGMQ queue.
+ *
+ * @param msgId Unique message ID assigned by PGMQ
+ * @param readCount Number of times this message has been read
+ * @param enqueuedAt When the message was enqueued
+ * @param visibilityTimeout When the message becomes visible again
+ * @param message The message payload
+ */
+public record PgmqMessage(
+    long msgId,
+    int readCount,
+    Instant enqueuedAt,
+    Instant visibilityTimeout,
+    Map<String, Object> message
+) {
+    /**
+     * Creates a PgmqMessage with an immutable copy of the message data.
+     */
+    public PgmqMessage {
+        if (message != null) {
+            message = Map.copyOf(message);
+        }
+    }
+}

--- a/src/main/java/com/commandbus/pgmq/PgmqClient.java
+++ b/src/main/java/com/commandbus/pgmq/PgmqClient.java
@@ -1,0 +1,135 @@
+package com.commandbus.pgmq;
+
+import com.commandbus.model.PgmqMessage;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Client for interacting with PGMQ queues.
+ *
+ * <p>Wraps PGMQ SQL functions for queue operations. All methods support
+ * both standalone execution and participation in existing transactions.
+ */
+public interface PgmqClient {
+
+    /**
+     * Create a queue if it doesn't exist.
+     *
+     * @param queueName Name of the queue to create
+     */
+    void createQueue(String queueName);
+
+    /**
+     * Send a message to a queue.
+     *
+     * @param queueName Name of the queue
+     * @param message Message payload (will be JSON serialized)
+     * @return Message ID assigned by PGMQ
+     */
+    long send(String queueName, Map<String, Object> message);
+
+    /**
+     * Send a message to a queue with delay.
+     *
+     * @param queueName Name of the queue
+     * @param message Message payload (will be JSON serialized)
+     * @param delaySeconds Delay in seconds before message becomes visible
+     * @return Message ID assigned by PGMQ
+     */
+    long send(String queueName, Map<String, Object> message, int delaySeconds);
+
+    /**
+     * Send multiple messages to a queue in a single operation.
+     *
+     * <p>Uses PGMQ's native send_batch() for optimal performance.
+     * Does NOT send NOTIFY - caller is responsible for notification.
+     *
+     * @param queueName Name of the queue
+     * @param messages List of message payloads
+     * @return List of message IDs assigned by PGMQ
+     */
+    List<Long> sendBatch(String queueName, List<Map<String, Object>> messages);
+
+    /**
+     * Send multiple messages with delay.
+     *
+     * @param queueName Name of the queue
+     * @param messages List of message payloads
+     * @param delaySeconds Delay in seconds
+     * @return List of message IDs
+     */
+    List<Long> sendBatch(String queueName, List<Map<String, Object>> messages, int delaySeconds);
+
+    /**
+     * Send a NOTIFY signal for a queue.
+     *
+     * <p>Used after batch operations to wake up workers.
+     *
+     * @param queueName Name of the queue
+     */
+    void notify(String queueName);
+
+    /**
+     * Read messages from a queue.
+     *
+     * @param queueName Name of the queue
+     * @param visibilityTimeoutSeconds Seconds before message becomes visible again
+     * @param batchSize Maximum number of messages to read
+     * @return List of messages (may be empty)
+     */
+    List<PgmqMessage> read(String queueName, int visibilityTimeoutSeconds, int batchSize);
+
+    /**
+     * Read a single message from a queue.
+     *
+     * @param queueName Name of the queue
+     * @param visibilityTimeoutSeconds Visibility timeout in seconds
+     * @return Optional message (empty if queue is empty)
+     */
+    default Optional<PgmqMessage> readOne(String queueName, int visibilityTimeoutSeconds) {
+        var messages = read(queueName, visibilityTimeoutSeconds, 1);
+        return messages.isEmpty() ? Optional.empty() : Optional.of(messages.get(0));
+    }
+
+    /**
+     * Delete a message from a queue.
+     *
+     * @param queueName Name of the queue
+     * @param msgId Message ID to delete
+     * @return true if message was deleted, false if not found
+     */
+    boolean delete(String queueName, long msgId);
+
+    /**
+     * Archive a message (move to archive table).
+     *
+     * @param queueName Name of the queue
+     * @param msgId Message ID to archive
+     * @return true if message was archived
+     */
+    boolean archive(String queueName, long msgId);
+
+    /**
+     * Set visibility timeout for a message.
+     *
+     * <p>Used for extending visibility timeout for long-running handlers
+     * or implementing backoff delays.
+     *
+     * @param queueName Name of the queue
+     * @param msgId Message ID
+     * @param visibilityTimeoutSeconds New visibility timeout in seconds from now
+     * @return true if timeout was set
+     */
+    boolean setVisibilityTimeout(String queueName, long msgId, int visibilityTimeoutSeconds);
+
+    /**
+     * Get message from archive by command ID.
+     *
+     * @param queueName Name of the queue
+     * @param commandId Command ID to search for
+     * @return Optional archived message
+     */
+    Optional<PgmqMessage> getFromArchive(String queueName, String commandId);
+}

--- a/src/main/java/com/commandbus/pgmq/QueueNames.java
+++ b/src/main/java/com/commandbus/pgmq/QueueNames.java
@@ -1,0 +1,77 @@
+package com.commandbus.pgmq;
+
+/**
+ * Queue naming utilities.
+ *
+ * <p>Provides standardized naming conventions for PGMQ queues used by the
+ * command bus. Queue names follow the pattern: {domain}__{suffix}
+ */
+public final class QueueNames {
+
+    private QueueNames() {
+        // Utility class - prevent instantiation
+    }
+
+    /** Suffix for command queues */
+    public static final String COMMANDS_SUFFIX = "commands";
+
+    /** Suffix for reply queues */
+    public static final String REPLIES_SUFFIX = "replies";
+
+    /** Prefix for NOTIFY channel names */
+    public static final String NOTIFY_PREFIX = "pgmq_notify";
+
+    /** Separator between domain and suffix */
+    public static final String SEPARATOR = "__";
+
+    /**
+     * Create command queue name from domain.
+     *
+     * @param domain The domain name
+     * @return Queue name in format {domain}__commands
+     */
+    public static String commandQueue(String domain) {
+        return domain + SEPARATOR + COMMANDS_SUFFIX;
+    }
+
+    /**
+     * Create reply queue name from domain.
+     *
+     * @param domain The domain name
+     * @return Queue name in format {domain}__replies
+     */
+    public static String replyQueue(String domain) {
+        return domain + SEPARATOR + REPLIES_SUFFIX;
+    }
+
+    /**
+     * Create notify channel name from queue name.
+     *
+     * @param queueName The queue name
+     * @return Channel name in format pgmq_notify_{queueName}
+     */
+    public static String notifyChannel(String queueName) {
+        return NOTIFY_PREFIX + "_" + queueName;
+    }
+
+    /**
+     * Extract domain from queue name.
+     *
+     * @param queueName The queue name
+     * @return The domain part, or the original queue name if no separator found
+     */
+    public static String extractDomain(String queueName) {
+        int separatorIndex = queueName.indexOf(SEPARATOR);
+        return separatorIndex > 0 ? queueName.substring(0, separatorIndex) : queueName;
+    }
+
+    /**
+     * Get the archive table name for a queue.
+     *
+     * @param queueName The queue name
+     * @return Archive table name in format pgmq.a_{queueName}
+     */
+    public static String archiveTable(String queueName) {
+        return "pgmq.a_" + queueName;
+    }
+}

--- a/src/test/java/com/commandbus/model/PgmqMessageTest.java
+++ b/src/test/java/com/commandbus/model/PgmqMessageTest.java
@@ -1,0 +1,114 @@
+package com.commandbus.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PgmqMessageTest {
+
+    @Test
+    void shouldCreateWithAllFields() {
+        Instant enqueuedAt = Instant.now().minusSeconds(60);
+        Instant visibilityTimeout = Instant.now().plusSeconds(30);
+        Map<String, Object> message = Map.of("key", "value");
+
+        PgmqMessage pgmqMessage = new PgmqMessage(
+            123L,
+            2,
+            enqueuedAt,
+            visibilityTimeout,
+            message
+        );
+
+        assertEquals(123L, pgmqMessage.msgId());
+        assertEquals(2, pgmqMessage.readCount());
+        assertEquals(enqueuedAt, pgmqMessage.enqueuedAt());
+        assertEquals(visibilityTimeout, pgmqMessage.visibilityTimeout());
+        assertEquals(Map.of("key", "value"), pgmqMessage.message());
+    }
+
+    @Test
+    void shouldCreateWithNullTimestamps() {
+        Map<String, Object> message = Map.of("key", "value");
+
+        PgmqMessage pgmqMessage = new PgmqMessage(
+            1L,
+            0,
+            null,
+            null,
+            message
+        );
+
+        assertNull(pgmqMessage.enqueuedAt());
+        assertNull(pgmqMessage.visibilityTimeout());
+    }
+
+    @Test
+    void shouldCreateWithNullMessage() {
+        PgmqMessage pgmqMessage = new PgmqMessage(
+            1L,
+            0,
+            null,
+            null,
+            null
+        );
+
+        assertNull(pgmqMessage.message());
+    }
+
+    @Test
+    void shouldMakeMessageImmutable() {
+        Map<String, Object> mutableMessage = new HashMap<>();
+        mutableMessage.put("key", "value");
+
+        PgmqMessage pgmqMessage = new PgmqMessage(
+            1L,
+            0,
+            null,
+            null,
+            mutableMessage
+        );
+
+        // Original map modification should not affect the record
+        mutableMessage.put("another", "entry");
+        assertEquals(1, pgmqMessage.message().size());
+
+        // Record's message should be immutable
+        assertThrows(UnsupportedOperationException.class,
+            () -> pgmqMessage.message().put("new", "entry"));
+    }
+
+    @Test
+    void shouldSupportEqualsAndHashCode() {
+        Instant now = Instant.now();
+        Map<String, Object> message = Map.of("key", "value");
+
+        PgmqMessage msg1 = new PgmqMessage(1L, 0, now, now, message);
+        PgmqMessage msg2 = new PgmqMessage(1L, 0, now, now, message);
+        PgmqMessage msg3 = new PgmqMessage(2L, 0, now, now, message);
+
+        assertEquals(msg1, msg2);
+        assertEquals(msg1.hashCode(), msg2.hashCode());
+        assertNotEquals(msg1, msg3);
+    }
+
+    @Test
+    void shouldHaveCorrectToString() {
+        PgmqMessage pgmqMessage = new PgmqMessage(
+            123L,
+            2,
+            null,
+            null,
+            Map.of("key", "value")
+        );
+
+        String toString = pgmqMessage.toString();
+        assertTrue(toString.contains("123"));
+        assertTrue(toString.contains("2"));
+        assertTrue(toString.contains("key"));
+    }
+}

--- a/src/test/java/com/commandbus/pgmq/QueueNamesTest.java
+++ b/src/test/java/com/commandbus/pgmq/QueueNamesTest.java
@@ -1,0 +1,70 @@
+package com.commandbus.pgmq;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueueNamesTest {
+
+    @Test
+    void commandQueueShouldReturnCorrectFormat() {
+        assertEquals("payments__commands", QueueNames.commandQueue("payments"));
+        assertEquals("orders__commands", QueueNames.commandQueue("orders"));
+        assertEquals("test__commands", QueueNames.commandQueue("test"));
+    }
+
+    @Test
+    void replyQueueShouldReturnCorrectFormat() {
+        assertEquals("payments__replies", QueueNames.replyQueue("payments"));
+        assertEquals("orders__replies", QueueNames.replyQueue("orders"));
+        assertEquals("test__replies", QueueNames.replyQueue("test"));
+    }
+
+    @Test
+    void notifyChannelShouldReturnCorrectFormat() {
+        assertEquals("pgmq_notify_payments__commands", QueueNames.notifyChannel("payments__commands"));
+        assertEquals("pgmq_notify_my_queue", QueueNames.notifyChannel("my_queue"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "payments__commands,payments",
+        "orders__replies,orders",
+        "test__commands,test",
+        "domain_with_underscore__commands,domain_with_underscore"
+    })
+    void extractDomainShouldExtractCorrectly(String queueName, String expectedDomain) {
+        assertEquals(expectedDomain, QueueNames.extractDomain(queueName));
+    }
+
+    @Test
+    void extractDomainShouldReturnOriginalWhenNoSeparator() {
+        assertEquals("queueWithoutSeparator", QueueNames.extractDomain("queueWithoutSeparator"));
+    }
+
+    @Test
+    void archiveTableShouldReturnCorrectFormat() {
+        assertEquals("pgmq.a_payments__commands", QueueNames.archiveTable("payments__commands"));
+        assertEquals("pgmq.a_test__replies", QueueNames.archiveTable("test__replies"));
+    }
+
+    @Test
+    void constantsShouldHaveExpectedValues() {
+        assertEquals("commands", QueueNames.COMMANDS_SUFFIX);
+        assertEquals("replies", QueueNames.REPLIES_SUFFIX);
+        assertEquals("pgmq_notify", QueueNames.NOTIFY_PREFIX);
+        assertEquals("__", QueueNames.SEPARATOR);
+    }
+
+    @Test
+    void commandAndReplyQueuesShouldUseSameDomain() {
+        String domain = "myservice";
+        String commandQueue = QueueNames.commandQueue(domain);
+        String replyQueue = QueueNames.replyQueue(domain);
+
+        assertEquals(domain, QueueNames.extractDomain(commandQueue));
+        assertEquals(domain, QueueNames.extractDomain(replyQueue));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PgmqMessage` record for PGMQ queue messages
- Add `PgmqClient` interface defining all PGMQ operations
- Add `QueueNames` utility with naming conventions

## Details

### PgmqMessage
Record containing message metadata from PGMQ:
- `msgId` - unique message ID
- `readCount` - number of times read
- `enqueuedAt` - when message was enqueued
- `visibilityTimeout` - when message becomes visible again
- `message` - payload as Map (immutable)

### PgmqClient Interface
Operations include:
- `createQueue(queueName)` - create a queue
- `send(queueName, message)` - send single message
- `sendBatch(queueName, messages)` - send multiple messages
- `read(queueName, vt, batchSize)` - read messages
- `delete(queueName, msgId)` - delete message
- `archive(queueName, msgId)` - archive message
- `setVisibilityTimeout(queueName, msgId, vt)` - extend visibility
- `notify(queueName)` - send NOTIFY signal

### QueueNames
Utility for standard queue naming:
- `commandQueue(domain)` → `{domain}__commands`
- `replyQueue(domain)` → `{domain}__replies`
- `notifyChannel(queueName)` → `pgmq_notify_{queueName}`

## Test plan
- [x] PgmqMessage creates correctly with all fields
- [x] PgmqMessage makes payload immutable
- [x] QueueNames generates correct queue names
- [x] QueueNames extracts domain from queue name
- [x] JaCoCo coverage > 80%

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)