### PR TITLE
Implement CommandRepository interface and JdbcCommandRepository

### DIFF
--- a/src/main/java/com/commandbus/repository/CommandRepository.java
+++ b/src/main/java/com/commandbus/repository/CommandRepository.java
@@ -1,0 +1,180 @@
+package com.commandbus.repository;
+
+import com.commandbus.model.CommandMetadata;
+import com.commandbus.model.CommandStatus;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Repository for command metadata.
+ */
+public interface CommandRepository {
+
+    /**
+     * Save command metadata.
+     *
+     * @param metadata The command metadata to save
+     * @param queueName The queue name for this command
+     */
+    void save(CommandMetadata metadata, String queueName);
+
+    /**
+     * Save multiple command metadata records.
+     *
+     * @param metadataList List of metadata to save
+     * @param queueName The queue name for these commands
+     */
+    void saveBatch(List<CommandMetadata> metadataList, String queueName);
+
+    /**
+     * Get command by domain and command ID.
+     *
+     * @param domain The domain
+     * @param commandId The command ID
+     * @return Optional containing metadata if found
+     */
+    Optional<CommandMetadata> get(String domain, UUID commandId);
+
+    /**
+     * Check if command exists.
+     *
+     * @param domain The domain
+     * @param commandId The command ID
+     * @return true if command exists
+     */
+    boolean exists(String domain, UUID commandId);
+
+    /**
+     * Check which command IDs exist from a list.
+     *
+     * @param domain The domain
+     * @param commandIds List of command IDs to check
+     * @return Set of command IDs that exist
+     */
+    Set<UUID> existsBatch(String domain, List<UUID> commandIds);
+
+    /**
+     * Update command status.
+     *
+     * @param domain The domain
+     * @param commandId The command ID
+     * @param status New status
+     */
+    void updateStatus(String domain, UUID commandId, CommandStatus status);
+
+    /**
+     * Query commands with filters.
+     *
+     * @param status Filter by status (nullable)
+     * @param domain Filter by domain (nullable)
+     * @param commandType Filter by command type (nullable)
+     * @param createdAfter Filter by created_at >= (nullable)
+     * @param createdBefore Filter by created_at <= (nullable)
+     * @param limit Maximum results
+     * @param offset Results to skip
+     * @return List of matching commands
+     */
+    List<CommandMetadata> query(
+        CommandStatus status,
+        String domain,
+        String commandType,
+        Instant createdAfter,
+        Instant createdBefore,
+        int limit,
+        int offset
+    );
+
+    /**
+     * List commands in a batch.
+     *
+     * @param domain The domain
+     * @param batchId The batch ID
+     * @param status Filter by status (nullable)
+     * @param limit Maximum results
+     * @param offset Results to skip
+     * @return List of commands in the batch
+     */
+    List<CommandMetadata> listByBatch(
+        String domain,
+        UUID batchId,
+        CommandStatus status,
+        int limit,
+        int offset
+    );
+
+    // --- Stored Procedure Wrappers ---
+
+    /**
+     * Atomically receive a command (stored procedure wrapper).
+     *
+     * <p>Combines: get metadata + increment attempts + update status + insert audit
+     *
+     * @param domain The domain
+     * @param commandId The command ID
+     * @param msgId The PGMQ message ID (nullable)
+     * @param maxAttempts Max attempts override (nullable)
+     * @return Optional containing updated metadata if found and receivable
+     */
+    Optional<CommandMetadata> spReceiveCommand(
+        String domain,
+        UUID commandId,
+        Long msgId,
+        Integer maxAttempts
+    );
+
+    /**
+     * Atomically finish a command (stored procedure wrapper).
+     *
+     * <p>Combines: update status/error + insert audit + update batch counters
+     *
+     * @param domain The domain
+     * @param commandId The command ID
+     * @param status Target status
+     * @param eventType Audit event type
+     * @param errorType Error type (nullable)
+     * @param errorCode Error code (nullable)
+     * @param errorMessage Error message (nullable)
+     * @param details Audit details (nullable)
+     * @param batchId Batch ID (nullable)
+     * @return true if batch is now complete
+     */
+    boolean spFinishCommand(
+        String domain,
+        UUID commandId,
+        CommandStatus status,
+        String eventType,
+        String errorType,
+        String errorCode,
+        String errorMessage,
+        String details,
+        UUID batchId
+    );
+
+    /**
+     * Record a transient failure (stored procedure wrapper).
+     *
+     * @param domain The domain
+     * @param commandId The command ID
+     * @param errorType Error type
+     * @param errorCode Error code
+     * @param errorMessage Error message
+     * @param attempt Current attempt number
+     * @param maxAttempts Max attempts
+     * @param msgId PGMQ message ID
+     * @return true if recorded
+     */
+    boolean spFailCommand(
+        String domain,
+        UUID commandId,
+        String errorType,
+        String errorCode,
+        String errorMessage,
+        int attempt,
+        int maxAttempts,
+        long msgId
+    );
+}

--- a/src/main/java/com/commandbus/repository/impl/JdbcCommandRepository.java
+++ b/src/main/java/com/commandbus/repository/impl/JdbcCommandRepository.java
@@ -1,0 +1,273 @@
+package com.commandbus.repository.impl;
+
+import com.commandbus.model.CommandMetadata;
+import com.commandbus.model.CommandStatus;
+import com.commandbus.repository.CommandRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * JDBC implementation of CommandRepository.
+ */
+@Repository
+public class JdbcCommandRepository implements CommandRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final RowMapper<CommandMetadata> METADATA_MAPPER = (rs, rowNum) -> {
+        return new CommandMetadata(
+            rs.getString("domain"),
+            UUID.fromString(rs.getString("command_id")),
+            rs.getString("command_type"),
+            CommandStatus.fromValue(rs.getString("status")),
+            rs.getInt("attempts"),
+            rs.getInt("max_attempts"),
+            rs.getObject("msg_id") != null ? rs.getLong("msg_id") : null,
+            rs.getString("correlation_id") != null ?
+                UUID.fromString(rs.getString("correlation_id")) : null,
+            rs.getString("reply_queue"),
+            rs.getString("last_error_type"),
+            rs.getString("last_error_code"),
+            rs.getString("last_error_msg"),
+            toInstant(rs.getTimestamp("created_at")),
+            toInstant(rs.getTimestamp("updated_at")),
+            rs.getString("batch_id") != null ?
+                UUID.fromString(rs.getString("batch_id")) : null
+        );
+    };
+
+    public JdbcCommandRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void save(CommandMetadata metadata, String queueName) {
+        jdbcTemplate.update("""
+            INSERT INTO commandbus.command (
+                domain, queue_name, msg_id, command_id, command_type,
+                status, attempts, max_attempts, correlation_id, reply_queue,
+                batch_id, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            metadata.domain(),
+            queueName,
+            metadata.msgId(),
+            metadata.commandId(),
+            metadata.commandType(),
+            metadata.status().getValue(),
+            metadata.attempts(),
+            metadata.maxAttempts(),
+            metadata.correlationId(),
+            metadata.replyTo(),
+            metadata.batchId(),
+            Timestamp.from(metadata.createdAt()),
+            Timestamp.from(metadata.updatedAt())
+        );
+    }
+
+    @Override
+    public void saveBatch(List<CommandMetadata> metadataList, String queueName) {
+        if (metadataList.isEmpty()) return;
+
+        String sql = """
+            INSERT INTO commandbus.command (
+                domain, queue_name, msg_id, command_id, command_type,
+                status, attempts, max_attempts, correlation_id, reply_queue,
+                batch_id, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+
+        List<Object[]> batchArgs = metadataList.stream()
+            .map(m -> new Object[]{
+                m.domain(), queueName, m.msgId(), m.commandId(), m.commandType(),
+                m.status().getValue(), m.attempts(), m.maxAttempts(),
+                m.correlationId(), m.replyTo(), m.batchId(),
+                Timestamp.from(m.createdAt()), Timestamp.from(m.updatedAt())
+            })
+            .toList();
+
+        jdbcTemplate.batchUpdate(sql, batchArgs);
+    }
+
+    @Override
+    public Optional<CommandMetadata> get(String domain, UUID commandId) {
+        List<CommandMetadata> results = jdbcTemplate.query(
+            "SELECT * FROM commandbus.command WHERE domain = ? AND command_id = ?",
+            METADATA_MAPPER,
+            domain, commandId
+        );
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+
+    @Override
+    public boolean exists(String domain, UUID commandId) {
+        Integer count = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM commandbus.command WHERE domain = ? AND command_id = ?",
+            Integer.class,
+            domain, commandId
+        );
+        return count != null && count > 0;
+    }
+
+    @Override
+    public Set<UUID> existsBatch(String domain, List<UUID> commandIds) {
+        if (commandIds.isEmpty()) return Set.of();
+
+        String placeholders = String.join(",", Collections.nCopies(commandIds.size(), "?"));
+        Object[] params = new Object[commandIds.size() + 1];
+        params[0] = domain;
+        for (int i = 0; i < commandIds.size(); i++) {
+            params[i + 1] = commandIds.get(i);
+        }
+
+        List<UUID> existing = jdbcTemplate.query(
+            "SELECT command_id FROM commandbus.command WHERE domain = ? AND command_id IN (" + placeholders + ")",
+            (rs, rowNum) -> UUID.fromString(rs.getString("command_id")),
+            params
+        );
+
+        return new HashSet<>(existing);
+    }
+
+    @Override
+    public void updateStatus(String domain, UUID commandId, CommandStatus status) {
+        jdbcTemplate.update(
+            "UPDATE commandbus.command SET status = ?, updated_at = NOW() WHERE domain = ? AND command_id = ?",
+            status.getValue(), domain, commandId
+        );
+    }
+
+    @Override
+    public List<CommandMetadata> query(
+            CommandStatus status,
+            String domain,
+            String commandType,
+            Instant createdAfter,
+            Instant createdBefore,
+            int limit,
+            int offset) {
+
+        StringBuilder sql = new StringBuilder("SELECT * FROM commandbus.command WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+
+        if (status != null) {
+            sql.append(" AND status = ?");
+            params.add(status.getValue());
+        }
+        if (domain != null) {
+            sql.append(" AND domain = ?");
+            params.add(domain);
+        }
+        if (commandType != null) {
+            sql.append(" AND command_type = ?");
+            params.add(commandType);
+        }
+        if (createdAfter != null) {
+            sql.append(" AND created_at >= ?");
+            params.add(Timestamp.from(createdAfter));
+        }
+        if (createdBefore != null) {
+            sql.append(" AND created_at <= ?");
+            params.add(Timestamp.from(createdBefore));
+        }
+
+        sql.append(" ORDER BY created_at DESC LIMIT ? OFFSET ?");
+        params.add(limit);
+        params.add(offset);
+
+        return jdbcTemplate.query(sql.toString(), METADATA_MAPPER, params.toArray());
+    }
+
+    @Override
+    public List<CommandMetadata> listByBatch(
+            String domain,
+            UUID batchId,
+            CommandStatus status,
+            int limit,
+            int offset) {
+
+        StringBuilder sql = new StringBuilder(
+            "SELECT * FROM commandbus.command WHERE domain = ? AND batch_id = ?"
+        );
+        List<Object> params = new ArrayList<>(List.of(domain, batchId));
+
+        if (status != null) {
+            sql.append(" AND status = ?");
+            params.add(status.getValue());
+        }
+
+        sql.append(" ORDER BY created_at ASC LIMIT ? OFFSET ?");
+        params.add(limit);
+        params.add(offset);
+
+        return jdbcTemplate.query(sql.toString(), METADATA_MAPPER, params.toArray());
+    }
+
+    @Override
+    public Optional<CommandMetadata> spReceiveCommand(
+            String domain,
+            UUID commandId,
+            Long msgId,
+            Integer maxAttempts) {
+
+        List<CommandMetadata> results = jdbcTemplate.query(
+            "SELECT * FROM commandbus.sp_receive_command(?, ?, 'IN_PROGRESS', ?, ?)",
+            METADATA_MAPPER,
+            domain, commandId, msgId, maxAttempts
+        );
+
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+
+    @Override
+    public boolean spFinishCommand(
+            String domain,
+            UUID commandId,
+            CommandStatus status,
+            String eventType,
+            String errorType,
+            String errorCode,
+            String errorMessage,
+            String details,
+            UUID batchId) {
+
+        Boolean result = jdbcTemplate.queryForObject(
+            "SELECT commandbus.sp_finish_command(?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?)",
+            Boolean.class,
+            domain, commandId, status.getValue(), eventType,
+            errorType, errorCode, errorMessage, details, batchId
+        );
+
+        return Boolean.TRUE.equals(result);
+    }
+
+    @Override
+    public boolean spFailCommand(
+            String domain,
+            UUID commandId,
+            String errorType,
+            String errorCode,
+            String errorMessage,
+            int attempt,
+            int maxAttempts,
+            long msgId) {
+
+        Boolean result = jdbcTemplate.queryForObject(
+            "SELECT commandbus.sp_fail_command(?, ?, ?, ?, ?, ?, ?, ?)",
+            Boolean.class,
+            domain, commandId, errorType, errorCode, errorMessage,
+            attempt, maxAttempts, msgId
+        );
+
+        return Boolean.TRUE.equals(result);
+    }
+
+    private static Instant toInstant(Timestamp ts) {
+        return ts != null ? ts.toInstant() : null;
+    }
+}

--- a/src/test/java/com/commandbus/repository/impl/JdbcCommandRepositoryTest.java
+++ b/src/test/java/com/commandbus/repository/impl/JdbcCommandRepositoryTest.java
@@ -1,0 +1,444 @@
+package com.commandbus.repository.impl;
+
+import com.commandbus.model.CommandMetadata;
+import com.commandbus.model.CommandStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JdbcCommandRepositoryTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private JdbcCommandRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new JdbcCommandRepository(jdbcTemplate);
+    }
+
+    private CommandMetadata createTestMetadata() {
+        return CommandMetadata.create("payments", UUID.randomUUID(), "DebitAccount", 3);
+    }
+
+    @Nested
+    class SaveTests {
+
+        @Test
+        void shouldSaveCommandMetadata() {
+            CommandMetadata metadata = createTestMetadata();
+
+            repository.save(metadata, "payments__commands");
+
+            verify(jdbcTemplate).update(
+                contains("INSERT INTO commandbus.command"),
+                eq(metadata.domain()),
+                eq("payments__commands"),
+                eq(metadata.msgId()),
+                eq(metadata.commandId()),
+                eq(metadata.commandType()),
+                eq(metadata.status().getValue()),
+                eq(metadata.attempts()),
+                eq(metadata.maxAttempts()),
+                eq(metadata.correlationId()),
+                eq(metadata.replyTo()),
+                eq(metadata.batchId()),
+                any(), any()
+            );
+        }
+    }
+
+    @Nested
+    class SaveBatchTests {
+
+        @Test
+        void shouldNotExecuteForEmptyList() {
+            repository.saveBatch(List.of(), "queue");
+            verifyNoInteractions(jdbcTemplate);
+        }
+
+        @Test
+        void shouldBatchInsertMetadata() {
+            List<CommandMetadata> metadataList = List.of(
+                createTestMetadata(),
+                createTestMetadata()
+            );
+
+            repository.saveBatch(metadataList, "payments__commands");
+
+            verify(jdbcTemplate).batchUpdate(
+                contains("INSERT INTO commandbus.command"),
+                anyList()
+            );
+        }
+    }
+
+    @Nested
+    class GetTests {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldReturnMetadataWhenFound() {
+            CommandMetadata expected = createTestMetadata();
+            UUID commandId = expected.commandId();
+
+            when(jdbcTemplate.query(
+                contains("SELECT * FROM commandbus.command WHERE domain"),
+                any(RowMapper.class),
+                eq("payments"), eq(commandId)
+            )).thenReturn(List.of(expected));
+
+            Optional<CommandMetadata> result = repository.get("payments", commandId);
+
+            assertTrue(result.isPresent());
+            assertEquals(expected, result.get());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldReturnEmptyWhenNotFound() {
+            when(jdbcTemplate.query(
+                anyString(),
+                any(RowMapper.class),
+                any(), any()
+            )).thenReturn(List.of());
+
+            Optional<CommandMetadata> result = repository.get("payments", UUID.randomUUID());
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    class ExistsTests {
+
+        @Test
+        void shouldReturnTrueWhenExists() {
+            when(jdbcTemplate.queryForObject(
+                contains("SELECT COUNT(*)"),
+                eq(Integer.class),
+                any(), any()
+            )).thenReturn(1);
+
+            assertTrue(repository.exists("payments", UUID.randomUUID()));
+        }
+
+        @Test
+        void shouldReturnFalseWhenNotExists() {
+            when(jdbcTemplate.queryForObject(
+                anyString(),
+                eq(Integer.class),
+                any(), any()
+            )).thenReturn(0);
+
+            assertFalse(repository.exists("payments", UUID.randomUUID()));
+        }
+
+        @Test
+        void shouldReturnFalseWhenNull() {
+            when(jdbcTemplate.queryForObject(
+                anyString(),
+                eq(Integer.class),
+                any(), any()
+            )).thenReturn(null);
+
+            assertFalse(repository.exists("payments", UUID.randomUUID()));
+        }
+    }
+
+    @Nested
+    class ExistsBatchTests {
+
+        @Test
+        void shouldReturnEmptySetForEmptyInput() {
+            Set<UUID> result = repository.existsBatch("payments", List.of());
+            assertTrue(result.isEmpty());
+            verifyNoInteractions(jdbcTemplate);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldReturnExistingIds() {
+            UUID id1 = UUID.randomUUID();
+            UUID id2 = UUID.randomUUID();
+            UUID id3 = UUID.randomUUID();
+
+            when(jdbcTemplate.query(
+                contains("SELECT command_id"),
+                any(RowMapper.class),
+                any(Object[].class)
+            )).thenReturn(List.of(id1, id3));
+
+            Set<UUID> result = repository.existsBatch("payments", List.of(id1, id2, id3));
+
+            assertEquals(Set.of(id1, id3), result);
+        }
+    }
+
+    @Nested
+    class UpdateStatusTests {
+
+        @Test
+        void shouldUpdateStatus() {
+            UUID commandId = UUID.randomUUID();
+
+            repository.updateStatus("payments", commandId, CommandStatus.COMPLETED);
+
+            verify(jdbcTemplate).update(
+                contains("UPDATE commandbus.command SET status"),
+                eq(CommandStatus.COMPLETED.getValue()),
+                eq("payments"),
+                eq(commandId)
+            );
+        }
+    }
+
+    @Nested
+    class QueryTests {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldQueryWithAllFilters() {
+            Instant after = Instant.now().minusSeconds(3600);
+            Instant before = Instant.now();
+
+            when(jdbcTemplate.query(
+                anyString(),
+                any(RowMapper.class),
+                any(Object[].class)
+            )).thenReturn(List.of());
+
+            repository.query(
+                CommandStatus.PENDING,
+                "payments",
+                "DebitAccount",
+                after,
+                before,
+                10,
+                0
+            );
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), any(Object[].class));
+
+            String sql = sqlCaptor.getValue();
+            assertTrue(sql.contains("status = ?"));
+            assertTrue(sql.contains("domain = ?"));
+            assertTrue(sql.contains("command_type = ?"));
+            assertTrue(sql.contains("created_at >= ?"));
+            assertTrue(sql.contains("created_at <= ?"));
+            assertTrue(sql.contains("LIMIT ? OFFSET ?"));
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldQueryWithNoFilters() {
+            when(jdbcTemplate.query(
+                anyString(),
+                any(RowMapper.class),
+                any(Object[].class)
+            )).thenReturn(List.of());
+
+            repository.query(null, null, null, null, null, 10, 0);
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), any(Object[].class));
+
+            String sql = sqlCaptor.getValue();
+            assertFalse(sql.contains("status = ?"));
+            assertFalse(sql.contains("AND domain = ?"));
+        }
+    }
+
+    @Nested
+    class ListByBatchTests {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldListByBatchWithStatus() {
+            UUID batchId = UUID.randomUUID();
+
+            when(jdbcTemplate.query(
+                anyString(),
+                any(RowMapper.class),
+                any(Object[].class)
+            )).thenReturn(List.of());
+
+            repository.listByBatch("payments", batchId, CommandStatus.PENDING, 10, 0);
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), any(Object[].class));
+
+            String sql = sqlCaptor.getValue();
+            assertTrue(sql.contains("batch_id = ?"));
+            assertTrue(sql.contains("status = ?"));
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldListByBatchWithoutStatus() {
+            UUID batchId = UUID.randomUUID();
+
+            when(jdbcTemplate.query(
+                anyString(),
+                any(RowMapper.class),
+                any(Object[].class)
+            )).thenReturn(List.of());
+
+            repository.listByBatch("payments", batchId, null, 10, 0);
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), any(Object[].class));
+
+            String sql = sqlCaptor.getValue();
+            assertTrue(sql.contains("batch_id = ?"));
+            assertFalse(sql.contains("status = ?"));
+        }
+    }
+
+    @Nested
+    class SpReceiveCommandTests {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldReturnMetadataWhenReceived() {
+            CommandMetadata expected = createTestMetadata();
+            UUID commandId = expected.commandId();
+
+            when(jdbcTemplate.query(
+                contains("sp_receive_command"),
+                any(RowMapper.class),
+                eq("payments"), eq(commandId), eq(123L), eq(5)
+            )).thenReturn(List.of(expected));
+
+            Optional<CommandMetadata> result = repository.spReceiveCommand(
+                "payments", commandId, 123L, 5
+            );
+
+            assertTrue(result.isPresent());
+            assertEquals(expected, result.get());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldReturnEmptyWhenNotReceivable() {
+            when(jdbcTemplate.query(
+                anyString(),
+                any(RowMapper.class),
+                any(), any(), any(), any()
+            )).thenReturn(List.of());
+
+            Optional<CommandMetadata> result = repository.spReceiveCommand(
+                "payments", UUID.randomUUID(), null, null
+            );
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    class SpFinishCommandTests {
+
+        @Test
+        void shouldReturnTrueWhenBatchComplete() {
+            when(jdbcTemplate.queryForObject(
+                contains("sp_finish_command"),
+                eq(Boolean.class),
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )).thenReturn(true);
+
+            boolean result = repository.spFinishCommand(
+                "payments",
+                UUID.randomUUID(),
+                CommandStatus.COMPLETED,
+                "COMPLETED",
+                null, null, null, null,
+                UUID.randomUUID()
+            );
+
+            assertTrue(result);
+        }
+
+        @Test
+        void shouldReturnFalseWhenNotComplete() {
+            when(jdbcTemplate.queryForObject(
+                anyString(),
+                eq(Boolean.class),
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )).thenReturn(false);
+
+            boolean result = repository.spFinishCommand(
+                "payments",
+                UUID.randomUUID(),
+                CommandStatus.COMPLETED,
+                "COMPLETED",
+                null, null, null, null,
+                null
+            );
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    class SpFailCommandTests {
+
+        @Test
+        void shouldReturnTrueWhenRecorded() {
+            when(jdbcTemplate.queryForObject(
+                contains("sp_fail_command"),
+                eq(Boolean.class),
+                any(), any(), any(), any(), any(), any(), any(), any()
+            )).thenReturn(true);
+
+            boolean result = repository.spFailCommand(
+                "payments",
+                UUID.randomUUID(),
+                "TRANSIENT",
+                "TIMEOUT",
+                "Connection timeout",
+                1, 3, 123L
+            );
+
+            assertTrue(result);
+        }
+
+        @Test
+        void shouldReturnFalseOnFailure() {
+            when(jdbcTemplate.queryForObject(
+                anyString(),
+                eq(Boolean.class),
+                any(), any(), any(), any(), any(), any(), any(), any()
+            )).thenReturn(false);
+
+            boolean result = repository.spFailCommand(
+                "payments",
+                UUID.randomUUID(),
+                "TRANSIENT",
+                "TIMEOUT",
+                "Error",
+                1, 3, 123L
+            );
+
+            assertFalse(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CommandRepository` interface defining all command metadata operations
- Implements `JdbcCommandRepository` using Spring JdbcTemplate
- Includes stored procedure wrappers: `spReceiveCommand`, `spFinishCommand`, `spFailCommand`
- Supports batch operations: `saveBatch`, `existsBatch`
- Provides flexible query operations with filtering by status, domain, command type, and date range

## Test plan
- [x] All 146 tests pass
- [x] 80%+ code coverage verified by JaCoCo
- [x] Nested test classes for organized test coverage of all repository methods

Story #30

🤖 Generated with [Claude Code](https://claude.ai/code)