### PR TITLE
Implement Handler annotation and HandlerRegistry

### DIFF
--- a/src/main/java/com/commandbus/handler/CommandHandler.java
+++ b/src/main/java/com/commandbus/handler/CommandHandler.java
@@ -1,0 +1,31 @@
+package com.commandbus.handler;
+
+import com.commandbus.model.Command;
+import com.commandbus.model.HandlerContext;
+
+/**
+ * Functional interface for command handlers.
+ *
+ * <p>Handlers process commands and optionally return a result that is
+ * included in the reply message.
+ *
+ * <p>Handlers can throw:
+ * <ul>
+ *   <li>{@link com.commandbus.exception.TransientCommandException} - for retryable failures</li>
+ *   <li>{@link com.commandbus.exception.PermanentCommandException} - for non-retryable failures</li>
+ *   <li>Any other exception - treated as transient failure</li>
+ * </ul>
+ */
+@FunctionalInterface
+public interface CommandHandler {
+
+    /**
+     * Process a command.
+     *
+     * @param command The command to process
+     * @param context Handler context with metadata and utilities
+     * @return Optional result to include in reply (may be null)
+     * @throws Exception on processing failure
+     */
+    Object handle(Command command, HandlerContext context) throws Exception;
+}

--- a/src/main/java/com/commandbus/handler/Handler.java
+++ b/src/main/java/com/commandbus/handler/Handler.java
@@ -1,0 +1,53 @@
+package com.commandbus.handler;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as a command handler.
+ *
+ * <p>Methods annotated with @Handler are automatically discovered and registered
+ * by the HandlerRegistry when component scanning is enabled.
+ *
+ * <p>Handler methods must have the signature:
+ * <pre>
+ * Object handleXxx(Command command, HandlerContext context)
+ * </pre>
+ *
+ * <p>The return value is serialized as JSON and included in the reply message
+ * if reply_to is configured. Return null for no result.
+ *
+ * <p>Example:
+ * <pre>
+ * {@literal @}Component
+ * public class PaymentHandlers {
+ *
+ *     {@literal @}Handler(domain = "payments", commandType = "DebitAccount")
+ *     public Map&lt;String, Object&gt; handleDebit(Command command, HandlerContext context) {
+ *         var amount = (Integer) command.data().get("amount");
+ *         // Process debit...
+ *         return Map.of("status", "debited", "balance", 900);
+ *     }
+ * }
+ * </pre>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Handler {
+
+    /**
+     * The domain this handler processes commands for.
+     *
+     * @return domain name (e.g., "payments")
+     */
+    String domain();
+
+    /**
+     * The command type this handler processes.
+     *
+     * @return command type (e.g., "DebitAccount")
+     */
+    String commandType();
+}

--- a/src/main/java/com/commandbus/handler/HandlerRegistry.java
+++ b/src/main/java/com/commandbus/handler/HandlerRegistry.java
@@ -1,0 +1,93 @@
+package com.commandbus.handler;
+
+import com.commandbus.model.Command;
+import com.commandbus.model.HandlerContext;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Registry for command handlers.
+ *
+ * <p>Maps (domain, commandType) pairs to handler functions. The registry
+ * discovers handlers via Spring component scanning and @Handler annotations.
+ */
+public interface HandlerRegistry {
+
+    /**
+     * Register a handler for a command type.
+     *
+     * @param domain The domain (e.g., "payments")
+     * @param commandType The command type (e.g., "DebitAccount")
+     * @param handler The handler function
+     * @throws com.commandbus.exception.HandlerAlreadyRegisteredException if handler exists
+     */
+    void register(String domain, String commandType, CommandHandler handler);
+
+    /**
+     * Get the handler for a command type.
+     *
+     * @param domain The domain
+     * @param commandType The command type
+     * @return Optional containing the handler if found
+     */
+    Optional<CommandHandler> get(String domain, String commandType);
+
+    /**
+     * Get the handler for a command type, throwing if not found.
+     *
+     * @param domain The domain
+     * @param commandType The command type
+     * @return The handler
+     * @throws com.commandbus.exception.HandlerNotFoundException if not found
+     */
+    CommandHandler getOrThrow(String domain, String commandType);
+
+    /**
+     * Dispatch a command to its registered handler.
+     *
+     * @param command The command to dispatch
+     * @param context Handler context
+     * @return Result from handler (may be null)
+     * @throws com.commandbus.exception.HandlerNotFoundException if no handler registered
+     * @throws Exception from handler execution
+     */
+    Object dispatch(Command command, HandlerContext context) throws Exception;
+
+    /**
+     * Check if a handler is registered.
+     *
+     * @param domain The domain
+     * @param commandType The command type
+     * @return true if handler is registered
+     */
+    boolean hasHandler(String domain, String commandType);
+
+    /**
+     * Get list of all registered (domain, commandType) pairs.
+     *
+     * @return List of registered handler keys
+     */
+    List<HandlerKey> registeredHandlers();
+
+    /**
+     * Remove all handlers. Useful for testing.
+     */
+    void clear();
+
+    /**
+     * Scan a Spring bean for @Handler annotated methods and register them.
+     *
+     * @param bean The bean to scan
+     * @return List of registered handler keys
+     */
+    List<HandlerKey> registerBean(Object bean);
+
+    /**
+     * Key for handler lookup.
+     *
+     * @param domain The domain
+     * @param commandType The command type
+     */
+    record HandlerKey(String domain, String commandType) {}
+}

--- a/src/main/java/com/commandbus/handler/impl/DefaultHandlerRegistry.java
+++ b/src/main/java/com/commandbus/handler/impl/DefaultHandlerRegistry.java
@@ -1,0 +1,136 @@
+package com.commandbus.handler.impl;
+
+import com.commandbus.exception.HandlerAlreadyRegisteredException;
+import com.commandbus.exception.HandlerNotFoundException;
+import com.commandbus.handler.CommandHandler;
+import com.commandbus.handler.Handler;
+import com.commandbus.handler.HandlerRegistry;
+import com.commandbus.model.Command;
+import com.commandbus.model.HandlerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default implementation of HandlerRegistry.
+ *
+ * <p>Implements BeanPostProcessor to automatically discover and register
+ * handlers from Spring beans annotated with @Handler.
+ */
+@Component
+public class DefaultHandlerRegistry implements HandlerRegistry, BeanPostProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultHandlerRegistry.class);
+
+    private final Map<HandlerKey, CommandHandler> handlers = new ConcurrentHashMap<>();
+
+    @Override
+    public void register(String domain, String commandType, CommandHandler handler) {
+        var key = new HandlerKey(domain, commandType);
+        if (handlers.containsKey(key)) {
+            throw new HandlerAlreadyRegisteredException(domain, commandType);
+        }
+        handlers.put(key, handler);
+        log.debug("Registered handler for {}.{}", domain, commandType);
+    }
+
+    @Override
+    public Optional<CommandHandler> get(String domain, String commandType) {
+        return Optional.ofNullable(handlers.get(new HandlerKey(domain, commandType)));
+    }
+
+    @Override
+    public CommandHandler getOrThrow(String domain, String commandType) {
+        return get(domain, commandType)
+            .orElseThrow(() -> new HandlerNotFoundException(domain, commandType));
+    }
+
+    @Override
+    public Object dispatch(Command command, HandlerContext context) throws Exception {
+        var handler = getOrThrow(command.domain(), command.commandType());
+        log.debug("Dispatching {}.{} (commandId={})",
+            command.domain(), command.commandType(), command.commandId());
+        return handler.handle(command, context);
+    }
+
+    @Override
+    public boolean hasHandler(String domain, String commandType) {
+        return handlers.containsKey(new HandlerKey(domain, commandType));
+    }
+
+    @Override
+    public List<HandlerKey> registeredHandlers() {
+        return List.copyOf(handlers.keySet());
+    }
+
+    @Override
+    public void clear() {
+        handlers.clear();
+    }
+
+    @Override
+    public List<HandlerKey> registerBean(Object bean) {
+        List<HandlerKey> registered = new ArrayList<>();
+
+        for (Method method : bean.getClass().getMethods()) {
+            Handler annotation = method.getAnnotation(Handler.class);
+            if (annotation == null) {
+                continue;
+            }
+
+            validateHandlerMethod(method);
+
+            String domain = annotation.domain();
+            String commandType = annotation.commandType();
+
+            CommandHandler handler = (command, context) -> {
+                return method.invoke(bean, command, context);
+            };
+
+            register(domain, commandType, handler);
+            registered.add(new HandlerKey(domain, commandType));
+
+            log.info("Discovered handler {}.{}() for {}.{}",
+                bean.getClass().getSimpleName(), method.getName(), domain, commandType);
+        }
+
+        return registered;
+    }
+
+    /**
+     * BeanPostProcessor callback - scans beans for @Handler methods.
+     */
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) {
+        boolean hasHandlers = Arrays.stream(bean.getClass().getMethods())
+            .anyMatch(m -> m.isAnnotationPresent(Handler.class));
+
+        if (hasHandlers) {
+            registerBean(bean);
+        }
+
+        return bean;
+    }
+
+    private void validateHandlerMethod(Method method) {
+        Class<?>[] params = method.getParameterTypes();
+        if (params.length != 2 ||
+            !params[0].equals(Command.class) ||
+            !params[1].equals(HandlerContext.class)) {
+
+            throw new IllegalArgumentException(
+                "Handler method " + method.getName() + " must have signature: " +
+                "Object methodName(Command command, HandlerContext context)"
+            );
+        }
+    }
+}

--- a/src/test/java/com/commandbus/handler/impl/DefaultHandlerRegistryTest.java
+++ b/src/test/java/com/commandbus/handler/impl/DefaultHandlerRegistryTest.java
@@ -1,0 +1,366 @@
+package com.commandbus.handler.impl;
+
+import com.commandbus.exception.HandlerAlreadyRegisteredException;
+import com.commandbus.exception.HandlerNotFoundException;
+import com.commandbus.exception.PermanentCommandException;
+import com.commandbus.exception.TransientCommandException;
+import com.commandbus.handler.CommandHandler;
+import com.commandbus.handler.Handler;
+import com.commandbus.handler.HandlerRegistry.HandlerKey;
+import com.commandbus.model.Command;
+import com.commandbus.model.HandlerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultHandlerRegistryTest {
+
+    private DefaultHandlerRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new DefaultHandlerRegistry();
+    }
+
+    private Command createTestCommand(String domain, String commandType) {
+        return new Command(
+            domain,
+            commandType,
+            UUID.randomUUID(),
+            Map.of("key", "value"),
+            null,
+            null,
+            Instant.now()
+        );
+    }
+
+    private HandlerContext createTestContext() {
+        return new HandlerContext(
+            createTestCommand("test", "Test"),
+            1,
+            3,
+            123L,
+            null
+        );
+    }
+
+    @Nested
+    class RegisterTests {
+
+        @Test
+        void shouldRegisterHandler() {
+            CommandHandler handler = (cmd, ctx) -> "result";
+
+            registry.register("payments", "DebitAccount", handler);
+
+            assertTrue(registry.hasHandler("payments", "DebitAccount"));
+        }
+
+        @Test
+        void shouldThrowOnDuplicateRegistration() {
+            CommandHandler handler = (cmd, ctx) -> "result";
+            registry.register("payments", "DebitAccount", handler);
+
+            assertThrows(HandlerAlreadyRegisteredException.class, () ->
+                registry.register("payments", "DebitAccount", handler));
+        }
+
+        @Test
+        void shouldAllowSameCommandTypeDifferentDomain() {
+            CommandHandler handler = (cmd, ctx) -> "result";
+
+            registry.register("payments", "Process", handler);
+            registry.register("orders", "Process", handler);
+
+            assertTrue(registry.hasHandler("payments", "Process"));
+            assertTrue(registry.hasHandler("orders", "Process"));
+        }
+    }
+
+    @Nested
+    class GetTests {
+
+        @Test
+        void shouldReturnHandlerWhenExists() {
+            CommandHandler handler = (cmd, ctx) -> "result";
+            registry.register("payments", "DebitAccount", handler);
+
+            var result = registry.get("payments", "DebitAccount");
+
+            assertTrue(result.isPresent());
+            assertEquals(handler, result.get());
+        }
+
+        @Test
+        void shouldReturnEmptyWhenNotExists() {
+            var result = registry.get("payments", "NonExistent");
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        void shouldGetOrThrowWhenExists() {
+            CommandHandler handler = (cmd, ctx) -> "result";
+            registry.register("payments", "DebitAccount", handler);
+
+            var result = registry.getOrThrow("payments", "DebitAccount");
+
+            assertEquals(handler, result);
+        }
+
+        @Test
+        void shouldThrowWhenNotFound() {
+            assertThrows(HandlerNotFoundException.class, () ->
+                registry.getOrThrow("payments", "NonExistent"));
+        }
+    }
+
+    @Nested
+    class DispatchTests {
+
+        @Test
+        void shouldDispatchToRegisteredHandler() throws Exception {
+            CommandHandler handler = (cmd, ctx) -> Map.of("status", "processed");
+            registry.register("payments", "DebitAccount", handler);
+
+            Command command = createTestCommand("payments", "DebitAccount");
+            HandlerContext context = createTestContext();
+
+            Object result = registry.dispatch(command, context);
+
+            assertEquals(Map.of("status", "processed"), result);
+        }
+
+        @Test
+        void shouldThrowWhenNoHandlerForDispatch() {
+            Command command = createTestCommand("payments", "NonExistent");
+            HandlerContext context = createTestContext();
+
+            assertThrows(HandlerNotFoundException.class, () ->
+                registry.dispatch(command, context));
+        }
+
+        @Test
+        void shouldPropagateTransientException() {
+            CommandHandler handler = (cmd, ctx) -> {
+                throw new TransientCommandException("TIMEOUT", "Connection timeout");
+            };
+            registry.register("payments", "DebitAccount", handler);
+
+            Command command = createTestCommand("payments", "DebitAccount");
+            HandlerContext context = createTestContext();
+
+            assertThrows(TransientCommandException.class, () ->
+                registry.dispatch(command, context));
+        }
+
+        @Test
+        void shouldPropagatePermanentException() {
+            CommandHandler handler = (cmd, ctx) -> {
+                throw new PermanentCommandException("VALIDATION", "Invalid amount");
+            };
+            registry.register("payments", "DebitAccount", handler);
+
+            Command command = createTestCommand("payments", "DebitAccount");
+            HandlerContext context = createTestContext();
+
+            assertThrows(PermanentCommandException.class, () ->
+                registry.dispatch(command, context));
+        }
+
+        @Test
+        void shouldReturnNullFromHandler() throws Exception {
+            CommandHandler handler = (cmd, ctx) -> null;
+            registry.register("payments", "DebitAccount", handler);
+
+            Command command = createTestCommand("payments", "DebitAccount");
+            HandlerContext context = createTestContext();
+
+            Object result = registry.dispatch(command, context);
+
+            assertNull(result);
+        }
+    }
+
+    @Nested
+    class HasHandlerTests {
+
+        @Test
+        void shouldReturnTrueWhenHandlerExists() {
+            registry.register("payments", "DebitAccount", (cmd, ctx) -> null);
+
+            assertTrue(registry.hasHandler("payments", "DebitAccount"));
+        }
+
+        @Test
+        void shouldReturnFalseWhenHandlerNotExists() {
+            assertFalse(registry.hasHandler("payments", "NonExistent"));
+        }
+    }
+
+    @Nested
+    class RegisteredHandlersTests {
+
+        @Test
+        void shouldReturnEmptyListWhenNoHandlers() {
+            List<HandlerKey> handlers = registry.registeredHandlers();
+
+            assertTrue(handlers.isEmpty());
+        }
+
+        @Test
+        void shouldReturnAllRegisteredHandlers() {
+            registry.register("payments", "Debit", (cmd, ctx) -> null);
+            registry.register("payments", "Credit", (cmd, ctx) -> null);
+            registry.register("orders", "Create", (cmd, ctx) -> null);
+
+            List<HandlerKey> handlers = registry.registeredHandlers();
+
+            assertEquals(3, handlers.size());
+            assertTrue(handlers.contains(new HandlerKey("payments", "Debit")));
+            assertTrue(handlers.contains(new HandlerKey("payments", "Credit")));
+            assertTrue(handlers.contains(new HandlerKey("orders", "Create")));
+        }
+    }
+
+    @Nested
+    class ClearTests {
+
+        @Test
+        void shouldRemoveAllHandlers() {
+            registry.register("payments", "Debit", (cmd, ctx) -> null);
+            registry.register("orders", "Create", (cmd, ctx) -> null);
+
+            registry.clear();
+
+            assertTrue(registry.registeredHandlers().isEmpty());
+            assertFalse(registry.hasHandler("payments", "Debit"));
+            assertFalse(registry.hasHandler("orders", "Create"));
+        }
+    }
+
+    @Nested
+    class RegisterBeanTests {
+
+        @Test
+        void shouldRegisterAnnotatedMethods() {
+            TestHandlerBean bean = new TestHandlerBean();
+
+            List<HandlerKey> registered = registry.registerBean(bean);
+
+            assertEquals(2, registered.size());
+            assertTrue(registry.hasHandler("test", "Command1"));
+            assertTrue(registry.hasHandler("test", "Command2"));
+        }
+
+        @Test
+        void shouldThrowOnInvalidMethodSignature() {
+            InvalidHandlerBean bean = new InvalidHandlerBean();
+
+            assertThrows(IllegalArgumentException.class, () ->
+                registry.registerBean(bean));
+        }
+
+        @Test
+        void shouldInvokeHandlerMethod() throws Exception {
+            TestHandlerBean bean = new TestHandlerBean();
+            registry.registerBean(bean);
+
+            Command command = createTestCommand("test", "Command1");
+            HandlerContext context = createTestContext();
+
+            Object result = registry.dispatch(command, context);
+
+            assertEquals("handled1", result);
+        }
+
+        @Test
+        void shouldSkipMethodsWithoutAnnotation() {
+            TestHandlerBean bean = new TestHandlerBean();
+
+            registry.registerBean(bean);
+
+            assertFalse(registry.hasHandler("test", "NotAHandler"));
+        }
+    }
+
+    @Nested
+    class BeanPostProcessorTests {
+
+        @Test
+        void shouldScanBeanWithHandlers() {
+            TestHandlerBean bean = new TestHandlerBean();
+
+            Object result = registry.postProcessAfterInitialization(bean, "testBean");
+
+            assertEquals(bean, result);
+            assertTrue(registry.hasHandler("test", "Command1"));
+            assertTrue(registry.hasHandler("test", "Command2"));
+        }
+
+        @Test
+        void shouldIgnoreBeanWithoutHandlers() {
+            Object bean = new Object();
+
+            Object result = registry.postProcessAfterInitialization(bean, "plainBean");
+
+            assertEquals(bean, result);
+            assertTrue(registry.registeredHandlers().isEmpty());
+        }
+    }
+
+    @Nested
+    class HandlerKeyTests {
+
+        @Test
+        void shouldBeEqualWithSameValues() {
+            HandlerKey key1 = new HandlerKey("payments", "Debit");
+            HandlerKey key2 = new HandlerKey("payments", "Debit");
+
+            assertEquals(key1, key2);
+            assertEquals(key1.hashCode(), key2.hashCode());
+        }
+
+        @Test
+        void shouldNotBeEqualWithDifferentValues() {
+            HandlerKey key1 = new HandlerKey("payments", "Debit");
+            HandlerKey key2 = new HandlerKey("payments", "Credit");
+
+            assertNotEquals(key1, key2);
+        }
+    }
+
+    // Test helper classes
+
+    static class TestHandlerBean {
+
+        @Handler(domain = "test", commandType = "Command1")
+        public String handleCommand1(Command command, HandlerContext context) {
+            return "handled1";
+        }
+
+        @Handler(domain = "test", commandType = "Command2")
+        public Map<String, Object> handleCommand2(Command command, HandlerContext context) {
+            return Map.of("result", "handled2");
+        }
+
+        public String notAHandler(Command command, HandlerContext context) {
+            return "not called";
+        }
+    }
+
+    static class InvalidHandlerBean {
+
+        @Handler(domain = "test", commandType = "Invalid")
+        public String invalidHandler(String wrongParam) {
+            return "invalid";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `@Handler` annotation for marking command handler methods
- Implements `CommandHandler` functional interface
- Implements `HandlerRegistry` interface for registration and dispatch
- `DefaultHandlerRegistry` with Spring BeanPostProcessor for auto-discovery
- Thread-safe registration using ConcurrentHashMap
- Method signature validation at registration time

## Test plan
- [x] All 211 tests pass
- [x] 80%+ code coverage verified by JaCoCo
- [x] Tests for registration, dispatch, exceptions, and bean scanning

Story #32

🤖 Generated with [Claude Code](https://claude.ai/code)