### PR TITLE
feat: implement BusinessRuleException for business rule failures

### DIFF
--- a/docs/business-rule-exception-spec.md
+++ b/docs/business-rule-exception-spec.md
@@ -1,0 +1,383 @@
+# BusinessRuleException Implementation Specification
+
+## Overview
+
+Port Python F016 (BusinessRuleException) to Java commandbus-spring. This introduces a new exception type that enables immediate command failure without operator intervention, triggering auto-compensation for processes.
+
+**Reference**: `/Users/igormusic/code/rcmd/docs/features/F016-business-rule-exception.md`
+
+---
+
+## Exception Hierarchy (Updated)
+
+```
+CommandBusException (base)
+├── TransientCommandException
+│   └── Behavior: Retry → (exhausted) → TSQ → Operator
+│
+├── PermanentCommandException
+│   └── Behavior: Immediate → TSQ → Operator
+│
+└── BusinessRuleException (NEW)
+    └── Behavior: Immediate → FAILED → Auto-compensate (for processes)
+```
+
+| Exception | Retry | TSQ | Operator | Auto-Compensate | Command Status |
+|-----------|-------|-----|----------|-----------------|----------------|
+| TransientCommandException | Yes | Yes (exhausted) | Yes | No | IN_TROUBLESHOOTING_QUEUE |
+| PermanentCommandException | No | Yes | Yes | No | IN_TROUBLESHOOTING_QUEUE |
+| BusinessRuleException | No | No | No | Yes | FAILED |
+
+---
+
+## Part 1: Core Library Changes
+
+### 1.1 BusinessRuleException Class
+
+**File**: `src/main/java/com/commandbus/exception/BusinessRuleException.java`
+
+```java
+package com.commandbus.exception;
+
+import java.util.Map;
+
+/**
+ * Raised for business rule violations that should fail immediately without TSQ.
+ *
+ * <p>When a handler throws this exception:
+ * <ul>
+ *   <li>Command status → FAILED (bypasses TSQ)</li>
+ *   <li>Reply sent with outcome=FAILED, errorType=BUSINESS_RULE</li>
+ *   <li>Process auto-compensates (no operator intervention)</li>
+ * </ul>
+ *
+ * <p>Use cases:
+ * <ul>
+ *   <li>Account closed before statement generation</li>
+ *   <li>Invalid date range in report request</li>
+ *   <li>Missing required data that won't appear later</li>
+ *   <li>Business validation rules that cannot be overridden</li>
+ * </ul>
+ */
+public class BusinessRuleException extends CommandBusException {
+
+    private final String code;
+    private final String errorMessage;
+    private final Map<String, Object> details;
+
+    public BusinessRuleException(String code, String message) {
+        this(code, message, Map.of());
+    }
+
+    public BusinessRuleException(String code, String message, Map<String, Object> details) {
+        super("[" + code + "] " + message);
+        this.code = code;
+        this.errorMessage = message;
+        this.details = details != null ? Map.copyOf(details) : Map.of();
+    }
+
+    public String getCode() { return code; }
+    public String getErrorMessage() { return errorMessage; }
+    public Map<String, Object> getDetails() { return details; }
+}
+```
+
+### 1.2 Reply Model Enhancement
+
+**File**: `src/main/java/com/commandbus/model/Reply.java`
+
+Add `errorType` field to distinguish failure types:
+
+```java
+public record Reply(
+    UUID commandId,
+    UUID correlationId,
+    ReplyOutcome outcome,
+    Map<String, Object> data,
+    String errorCode,
+    String errorMessage,
+    String errorType      // NEW: "PERMANENT", "TRANSIENT", "BUSINESS_RULE"
+) {
+    // Add factory method
+    public static Reply businessRuleFailed(UUID commandId, UUID correlationId,
+                                           String errorCode, String errorMessage) {
+        return new Reply(commandId, correlationId, ReplyOutcome.FAILED,
+                        null, errorCode, errorMessage, "BUSINESS_RULE");
+    }
+}
+```
+
+### 1.3 Worker Exception Handling
+
+**File**: `src/main/java/com/commandbus/worker/impl/DefaultWorker.java`
+
+Add catch block for BusinessRuleException in `processMessageInternal()`:
+
+```java
+try {
+    Object result = handlerRegistry.dispatch(command, context);
+    complete(metadata, pgmqMessage.msgId(), result);
+
+} catch (BusinessRuleException e) {
+    handleBusinessRuleError(commandId, pgmqMessage.msgId(), e);  // NEW
+} catch (TransientCommandException e) {
+    handleTransientError(commandId, pgmqMessage.msgId(), e);
+} catch (PermanentCommandException e) {
+    handlePermanentError(commandId, pgmqMessage.msgId(), e);
+} catch (Exception e) {
+    handleTransientError(commandId, pgmqMessage.msgId(),
+        new TransientCommandException("INTERNAL_ERROR", e.getMessage()));
+}
+```
+
+Add new handler method:
+
+```java
+private void handleBusinessRuleError(UUID commandId, Long msgId, BusinessRuleException e) {
+    log.debug("Business rule error for command {}: {}", commandId, e.getMessage());
+
+    CommandMetadata metadata = commandRepository.get(domain, commandId).orElse(null);
+    if (metadata == null) return;
+
+    // Archive message (remove from queue)
+    pgmqClient.archive(queueName, msgId);
+
+    // Update command status to FAILED (NOT IN_TROUBLESHOOTING_QUEUE)
+    commandRepository.spFinishCommand(
+        domain, commandId,
+        CommandStatus.FAILED,           // Key difference from PermanentCommandException
+        "BUSINESS_RULE_FAILED",
+        "BUSINESS_RULE", e.getCode(), e.getErrorMessage(),
+        null, metadata.batchId()
+    );
+
+    // Send reply with errorType=BUSINESS_RULE
+    sendBusinessRuleReply(metadata, e);
+
+    log.warn("Command {} failed due to business rule: [{}] {}",
+        commandId, e.getCode(), e.getErrorMessage());
+}
+
+private void sendBusinessRuleReply(CommandMetadata metadata, BusinessRuleException e) {
+    if (metadata.replyTo() == null || metadata.replyTo().isBlank()) return;
+
+    Map<String, Object> reply = Map.of(
+        "command_id", metadata.commandId().toString(),
+        "correlation_id", metadata.correlationId() != null
+            ? metadata.correlationId().toString() : "",
+        "outcome", "FAILED",
+        "error_type", "BUSINESS_RULE",    // Key for process manager
+        "error_code", e.getCode(),
+        "error_message", e.getErrorMessage()
+    );
+
+    pgmqClient.send(metadata.replyTo(), reply);
+}
+```
+
+### 1.4 Process Manager Auto-Compensation
+
+**File**: `src/main/java/com/commandbus/process/BaseProcessManager.java`
+
+Modify `handleReplyInternal()` to check error_type:
+
+```java
+case FAILED -> {
+    String errorType = getErrorType(reply);  // Extract from reply data
+
+    if ("BUSINESS_RULE".equals(errorType)) {
+        // Auto-compensate for business rule failures
+        log.info("Process {} command failed due to business rule, auto-compensating",
+            process.processId());
+        runCompensations(typed, jdbc);
+    } else {
+        // Wait for TSQ intervention (existing behavior)
+        handleFailure(typed, reply, jdbc);
+    }
+}
+```
+
+Add helper method:
+
+```java
+private String getErrorType(Reply reply) {
+    // Check if errorType field exists
+    return reply.errorType() != null ? reply.errorType() : "PERMANENT";
+}
+```
+
+### 1.5 Audit Event Type
+
+**File**: `src/main/java/com/commandbus/model/AuditEventType.java`
+
+Add new event type:
+
+```java
+public enum AuditEventType {
+    // ... existing types
+    BUSINESS_RULE_FAILED   // NEW: Command failed due to business rule
+}
+```
+
+---
+
+## Part 2: E2E Test Application Changes
+
+### 2.1 Test Handler for BusinessRuleException
+
+**File**: `src/test/java/com/commandbus/e2e/handlers/TestHandlers.java`
+
+Add new handler:
+
+```java
+@PostConstruct
+public void registerHandlers() {
+    // ... existing handlers
+    handlerRegistry.register(domain, "BusinessRuleFailCommand", this::handleBusinessRuleFail);
+}
+
+/**
+ * Handler that fails with BusinessRuleException.
+ */
+public Map<String, Object> handleBusinessRuleFail(Command command, HandlerContext context) {
+    log.info("Processing BusinessRuleFailCommand: {}", command.commandId());
+    throw new BusinessRuleException("ACCOUNT_CLOSED",
+        "Cannot process - account is closed");
+}
+```
+
+### 2.2 Probabilistic Handler Enhancement
+
+**File**: `src/test/java/com/commandbus/e2e/handlers/ProbabilisticHandler.java` (new or extend existing)
+
+Add `failBusinessRulePct` to behavior configuration:
+
+```java
+public record CommandBehavior(
+    double failPermanentPct,
+    double failTransientPct,
+    double failBusinessRulePct,  // NEW
+    double timeoutPct,
+    int minDurationMs,
+    int maxDurationMs
+) {}
+
+public Map<String, Object> handle(Command command, HandlerContext context) {
+    double roll = random.nextDouble() * 100;
+    double cumulative = 0;
+
+    // Evaluation order: permanent → transient → business_rule → timeout → success
+    cumulative += behavior.failPermanentPct();
+    if (roll < cumulative) {
+        throw new PermanentCommandException("PERM_ERROR", "Simulated permanent error");
+    }
+
+    cumulative += behavior.failTransientPct();
+    if (roll < cumulative) {
+        throw new TransientCommandException("TRANS_ERROR", "Simulated transient error");
+    }
+
+    cumulative += behavior.failBusinessRulePct();
+    if (roll < cumulative) {
+        throw new BusinessRuleException("BIZ_RULE", "Simulated business rule violation");
+    }
+
+    cumulative += behavior.timeoutPct();
+    if (roll < cumulative) {
+        simulateTimeout();
+    }
+
+    return Map.of("status", "success");
+}
+```
+
+### 2.3 E2E UI Updates
+
+**Files to modify**:
+- `src/test/resources/templates/e2e/pages/batch_new.html`
+- `src/test/resources/templates/e2e/pages/send_command.html`
+
+Add `failBusinessRulePct` input field alongside existing probability fields:
+
+```html
+<div class="col-md-3">
+    <label class="form-label">Business Rule Fail %</label>
+    <input type="number" name="failBusinessRulePct" class="form-control"
+           min="0" max="100" step="0.1" value="0">
+</div>
+```
+
+Update expected outcome preview to include business rule failures.
+
+---
+
+## Part 3: Files to Modify/Create
+
+### New Files
+| File | Description |
+|------|-------------|
+| `src/main/java/com/commandbus/exception/BusinessRuleException.java` | New exception class |
+| `src/test/java/com/commandbus/exception/BusinessRuleExceptionTest.java` | Unit tests |
+
+### Modified Files (Core Library)
+| File | Changes |
+|------|---------|
+| `src/main/java/com/commandbus/model/Reply.java` | Add errorType field |
+| `src/main/java/com/commandbus/model/AuditEventType.java` | Add BUSINESS_RULE_FAILED |
+| `src/main/java/com/commandbus/worker/impl/DefaultWorker.java` | Catch BusinessRuleException, new handler method |
+| `src/main/java/com/commandbus/process/BaseProcessManager.java` | Auto-compensate on BUSINESS_RULE errorType |
+
+### Modified Files (E2E)
+| File | Changes |
+|------|---------|
+| `src/test/java/com/commandbus/e2e/handlers/TestHandlers.java` | Add BusinessRuleFailCommand handler |
+| `src/test/resources/templates/e2e/pages/batch_new.html` | Add failBusinessRulePct field |
+| `src/test/resources/templates/e2e/pages/send_command.html` | Add failBusinessRulePct field |
+
+---
+
+## Part 4: Implementation Order
+
+1. **BusinessRuleException class** - Create exception with code, message, details
+2. **Reply model update** - Add errorType field, factory method
+3. **Worker handling** - Catch exception, set FAILED status, send reply with errorType
+4. **Audit event type** - Add BUSINESS_RULE_FAILED
+5. **Process Manager** - Check errorType, auto-compensate for BUSINESS_RULE
+6. **Unit tests** - Exception, worker handling, process compensation
+7. **E2E handlers** - BusinessRuleFailCommand
+8. **E2E UI** - failBusinessRulePct in batch creation forms
+
+---
+
+## Part 5: Verification
+
+### Unit Tests
+- [ ] BusinessRuleException creation with code, message, details
+- [ ] Worker catches BusinessRuleException → status FAILED
+- [ ] Worker sends reply with errorType=BUSINESS_RULE
+- [ ] ProcessManager auto-compensates on BUSINESS_RULE errorType
+- [ ] ProcessManager waits for TSQ on PERMANENT errorType (existing behavior)
+
+### Integration Tests
+- [ ] Full flow: send command → BusinessRuleException → FAILED status → compensation
+- [ ] Verify command NOT in TSQ
+- [ ] Verify process ends in CANCELED status after compensation
+
+### E2E Tests
+- [ ] Create batch with failBusinessRulePct
+- [ ] Verify correct distribution of failures
+- [ ] Verify UI shows business rule failures distinctly
+
+### Manual Verification
+```bash
+# Start E2E app
+mvn spring-boot:test-run -Dspring-boot.run.profiles=e2e,ui
+
+# Start worker
+mvn spring-boot:test-run -Dspring-boot.run.profiles=e2e,worker
+
+# Send BusinessRuleFailCommand via UI or curl
+# Verify: command status = FAILED (not IN_TROUBLESHOOTING_QUEUE)
+# Verify: not visible in TSQ page
+# Verify: process auto-compensates if applicable
+```

--- a/src/main/java/com/commandbus/exception/BusinessRuleException.java
+++ b/src/main/java/com/commandbus/exception/BusinessRuleException.java
@@ -1,0 +1,51 @@
+package com.commandbus.exception;
+
+import java.util.Map;
+
+/**
+ * Raised for business rule violations that should fail immediately without TSQ.
+ *
+ * <p>When a handler throws this exception:
+ * <ul>
+ *   <li>Command status → FAILED (bypasses TSQ)</li>
+ *   <li>Reply sent with outcome=FAILED, errorType=BUSINESS_RULE</li>
+ *   <li>Process auto-compensates (no operator intervention)</li>
+ * </ul>
+ *
+ * <p>Use cases:
+ * <ul>
+ *   <li>Account closed before statement generation</li>
+ *   <li>Invalid date range in report request</li>
+ *   <li>Missing required data that won't appear later</li>
+ *   <li>Business validation rules that cannot be overridden</li>
+ * </ul>
+ */
+public class BusinessRuleException extends CommandBusException {
+
+    private final String code;
+    private final String errorMessage;
+    private final Map<String, Object> details;
+
+    public BusinessRuleException(String code, String message) {
+        this(code, message, Map.of());
+    }
+
+    public BusinessRuleException(String code, String message, Map<String, Object> details) {
+        super("[" + code + "] " + message);
+        this.code = code;
+        this.errorMessage = message;
+        this.details = details != null ? Map.copyOf(details) : Map.of();
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Map<String, Object> getDetails() {
+        return details;
+    }
+}

--- a/src/main/java/com/commandbus/model/AuditEventType.java
+++ b/src/main/java/com/commandbus/model/AuditEventType.java
@@ -18,6 +18,9 @@ public final class AuditEventType {
     /** Command failed (transient or permanent) */
     public static final String FAILED = "FAILED";
 
+    /** Command failed due to business rule violation (bypasses TSQ) */
+    public static final String BUSINESS_RULE_FAILED = "BUSINESS_RULE_FAILED";
+
     /** Command scheduled for retry */
     public static final String RETRY_SCHEDULED = "RETRY_SCHEDULED";
 

--- a/src/main/java/com/commandbus/process/ProcessReplyRouter.java
+++ b/src/main/java/com/commandbus/process/ProcessReplyRouter.java
@@ -321,8 +321,9 @@ public class ProcessReplyRouter {
         Map<String, Object> resultData = (Map<String, Object>) message.get("result");
         String errorCode = (String) message.get("error_code");
         String errorMessage = (String) message.get("error_message");
+        String errorType = (String) message.get("error_type");
 
-        return new Reply(commandId, correlationId, outcome, resultData, errorCode, errorMessage);
+        return new Reply(commandId, correlationId, outcome, resultData, errorCode, errorMessage, errorType);
     }
 
     private UUID parseUUID(Object value) {

--- a/src/test/java/com/commandbus/exception/ExceptionTest.java
+++ b/src/test/java/com/commandbus/exception/ExceptionTest.java
@@ -249,4 +249,56 @@ class ExceptionTest {
             assertInstanceOf(CommandBusException.class, exception);
         }
     }
+
+    @Nested
+    class BusinessRuleExceptionTest {
+
+        @Test
+        void shouldCreateWithCodeAndMessage() {
+            BusinessRuleException exception = new BusinessRuleException("ACCOUNT_CLOSED", "Account is closed");
+
+            assertEquals("ACCOUNT_CLOSED", exception.getCode());
+            assertEquals("Account is closed", exception.getErrorMessage());
+            assertEquals("[ACCOUNT_CLOSED] Account is closed", exception.getMessage());
+            assertEquals(Map.of(), exception.getDetails());
+        }
+
+        @Test
+        void shouldCreateWithDetails() {
+            Map<String, Object> details = Map.of("accountId", "acc-123", "closedAt", "2024-01-15");
+            BusinessRuleException exception = new BusinessRuleException("ACCOUNT_CLOSED", "Account is closed", details);
+
+            assertEquals("ACCOUNT_CLOSED", exception.getCode());
+            assertEquals("Account is closed", exception.getErrorMessage());
+            assertEquals(details, exception.getDetails());
+        }
+
+        @Test
+        void shouldMakeDetailsImmutable() {
+            Map<String, Object> mutableDetails = new HashMap<>();
+            mutableDetails.put("key", "value");
+
+            BusinessRuleException exception = new BusinessRuleException("CODE", "msg", mutableDetails);
+
+            // Original map modification should not affect exception
+            mutableDetails.put("another", "entry");
+            assertEquals(1, exception.getDetails().size());
+
+            // Exception details should be immutable
+            assertThrows(UnsupportedOperationException.class,
+                () -> exception.getDetails().put("new", "entry"));
+        }
+
+        @Test
+        void shouldHandleNullDetails() {
+            BusinessRuleException exception = new BusinessRuleException("CODE", "msg", null);
+            assertEquals(Map.of(), exception.getDetails());
+        }
+
+        @Test
+        void shouldBeCommandBusException() {
+            BusinessRuleException exception = new BusinessRuleException("CODE", "msg");
+            assertInstanceOf(CommandBusException.class, exception);
+        }
+    }
 }

--- a/src/test/java/com/commandbus/model/BatchCommandTest.java
+++ b/src/test/java/com/commandbus/model/BatchCommandTest.java
@@ -1,0 +1,83 @@
+package com.commandbus.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BatchCommand")
+class BatchCommandTest {
+
+    @Test
+    @DisplayName("should create batch command with all fields")
+    void shouldCreateBatchCommandWithAllFields() {
+        UUID commandId = UUID.randomUUID();
+        UUID correlationId = UUID.randomUUID();
+        Map<String, Object> data = Map.of("key", "value");
+
+        BatchCommand cmd = new BatchCommand(
+            "TestCommand", commandId, data, correlationId, "reply_queue", 5
+        );
+
+        assertEquals("TestCommand", cmd.commandType());
+        assertEquals(commandId, cmd.commandId());
+        assertEquals(data, cmd.data());
+        assertEquals(correlationId, cmd.correlationId());
+        assertEquals("reply_queue", cmd.replyTo());
+        assertEquals(5, cmd.maxAttempts());
+    }
+
+    @Test
+    @DisplayName("should throw on null command type")
+    void shouldThrowOnNullCommandType() {
+        UUID commandId = UUID.randomUUID();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> new BatchCommand(null, commandId, Map.of(), null, null, null));
+    }
+
+    @Test
+    @DisplayName("should throw on blank command type")
+    void shouldThrowOnBlankCommandType() {
+        UUID commandId = UUID.randomUUID();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> new BatchCommand("   ", commandId, Map.of(), null, null, null));
+    }
+
+    @Test
+    @DisplayName("should throw on null command id")
+    void shouldThrowOnNullCommandId() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new BatchCommand("TestCommand", null, Map.of(), null, null, null));
+    }
+
+    @Test
+    @DisplayName("should default null data to empty map")
+    void shouldDefaultNullDataToEmptyMap() {
+        UUID commandId = UUID.randomUUID();
+
+        BatchCommand cmd = new BatchCommand("TestCommand", commandId, null, null, null, null);
+
+        assertEquals(Map.of(), cmd.data());
+    }
+
+    @Test
+    @DisplayName("should create simple batch command via factory method")
+    void shouldCreateSimpleBatchCommandViaFactoryMethod() {
+        UUID commandId = UUID.randomUUID();
+        Map<String, Object> data = Map.of("key", "value");
+
+        BatchCommand cmd = BatchCommand.of("TestCommand", commandId, data);
+
+        assertEquals("TestCommand", cmd.commandType());
+        assertEquals(commandId, cmd.commandId());
+        assertEquals(data, cmd.data());
+        assertNull(cmd.correlationId());
+        assertNull(cmd.replyTo());
+        assertNull(cmd.maxAttempts());
+    }
+}

--- a/src/test/java/com/commandbus/model/ReplyTest.java
+++ b/src/test/java/com/commandbus/model/ReplyTest.java
@@ -78,4 +78,46 @@ class ReplyTest {
 
         assertNull(reply.correlationId());
     }
+
+    @Test
+    @DisplayName("should create business rule failed reply")
+    void shouldCreateBusinessRuleFailedReply() {
+        UUID commandId = UUID.randomUUID();
+        UUID correlationId = UUID.randomUUID();
+
+        Reply reply = Reply.businessRuleFailed(commandId, correlationId, "ACCOUNT_CLOSED", "Account is closed");
+
+        assertEquals(commandId, reply.commandId());
+        assertEquals(correlationId, reply.correlationId());
+        assertEquals(ReplyOutcome.FAILED, reply.outcome());
+        assertNull(reply.data());
+        assertEquals("ACCOUNT_CLOSED", reply.errorCode());
+        assertEquals("Account is closed", reply.errorMessage());
+        assertEquals("BUSINESS_RULE", reply.errorType());
+        assertTrue(reply.isBusinessRuleFailure());
+        assertTrue(reply.isFailed());
+        assertFalse(reply.isSuccess());
+        assertFalse(reply.isCanceled());
+    }
+
+    @Test
+    @DisplayName("should not be business rule failure for regular failed reply")
+    void shouldNotBeBusinessRuleFailureForRegularFailed() {
+        UUID commandId = UUID.randomUUID();
+
+        Reply reply = Reply.failed(commandId, null, "ERR001", "Error");
+
+        assertFalse(reply.isBusinessRuleFailure());
+        assertEquals("PERMANENT", reply.errorType());  // Regular failed defaults to PERMANENT
+    }
+
+    @Test
+    @DisplayName("should not be business rule failure for success reply")
+    void shouldNotBeBusinessRuleFailureForSuccess() {
+        UUID commandId = UUID.randomUUID();
+
+        Reply reply = Reply.success(commandId, null, Map.of());
+
+        assertFalse(reply.isBusinessRuleFailure());
+    }
 }

--- a/src/test/java/com/commandbus/process/ProcessResponseTest.java
+++ b/src/test/java/com/commandbus/process/ProcessResponseTest.java
@@ -67,7 +67,7 @@ class ProcessResponseTest {
     @DisplayName("should handle null data in success reply")
     void shouldHandleNullDataInSuccessReply() {
         UUID commandId = UUID.randomUUID();
-        Reply reply = new Reply(commandId, null, ReplyOutcome.SUCCESS, null, null, null);
+        Reply reply = new Reply(commandId, null, ReplyOutcome.SUCCESS, null, null, null, null);
 
         ProcessResponse<PaymentResult> response = ProcessResponse.fromReply(
             reply,


### PR DESCRIPTION
## Summary

- Port Python F016 (BusinessRuleException) to Java commandbus-spring
- Add new exception type that bypasses TSQ and sets command status to FAILED
- Enable auto-compensation for processes when business rule failures occur

### Changes

- **BusinessRuleException**: New exception class for business rule violations
- **Reply.errorType**: Added field to distinguish PERMANENT vs BUSINESS_RULE failures  
- **DefaultWorker**: Catches BusinessRuleException, archives message, sets FAILED status
- **BaseProcessManager**: Auto-compensates when errorType is BUSINESS_RULE
- **AuditEventType**: Added BUSINESS_RULE_FAILED constant

## Test plan

- [x] Unit tests for BusinessRuleException class
- [x] Worker tests for BusinessRuleException handling
- [x] Process manager tests for auto-compensation on business rule failure
- [x] Reply model tests for new factory method and helper
- [x] All 476 tests pass with 80%+ coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)