### PR TITLE
feat: add batch process startup for improved performance

### DIFF
--- a/src/test/java/com/ivamare/commandbus/e2e/E2ETestApplication.java
+++ b/src/test/java/com/ivamare/commandbus/e2e/E2ETestApplication.java
@@ -75,7 +75,7 @@ public class E2ETestApplication {
             "payments__process_replies",
             "payments",
             30,   // visibilityTimeout
-            2,    // concurrency
+            20,   // concurrency - increased from 2 for better throughput
             500,  // pollIntervalMs
             true  // useNotify
         );

--- a/src/test/java/com/ivamare/commandbus/e2e/payment/PaymentProcessManager.java
+++ b/src/test/java/com/ivamare/commandbus/e2e/payment/PaymentProcessManager.java
@@ -15,7 +15,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -324,5 +326,29 @@ public class PaymentProcessManager
             initialData.put("behavior", behavior.toMap());
         }
         return start(initialData);
+    }
+
+    /**
+     * Start payment processes for multiple payments in a single batch operation.
+     * This is significantly faster than calling startPayment() for each payment individually.
+     *
+     * @param payments List of payments to start processes for
+     * @param behavior Optional behavior configuration applied to all payments
+     * @return List of process IDs, in same order as input payments
+     */
+    public List<UUID> startPaymentBatch(List<Payment> payments, PaymentStepBehavior behavior) {
+        List<Map<String, Object>> initialDataList = new ArrayList<>(payments.size());
+
+        for (Payment payment : payments) {
+            Map<String, Object> initialData = new HashMap<>();
+            initialData.put("payment_id", payment.paymentId().toString());
+            initialData.put("fx_required", payment.requiresFx());
+            if (behavior != null) {
+                initialData.put("behavior", behavior.toMap());
+            }
+            initialDataList.add(initialData);
+        }
+
+        return startBatch(initialDataList);
     }
 }

--- a/src/test/java/com/ivamare/commandbus/e2e/service/E2EService.java
+++ b/src/test/java/com/ivamare/commandbus/e2e/service/E2EService.java
@@ -859,10 +859,9 @@ public class E2EService {
         // Save batch and payments
         ((JdbcPaymentRepository) paymentRepository).saveBatch(batchId, request.name(), payments);
 
-        // Start processes for each payment
-        for (Payment payment : payments) {
-            paymentProcessManager.startPayment(payment, request.behavior());
-        }
+        // Start processes for all payments in a single batch operation
+        // This is dramatically faster than starting processes one by one
+        paymentProcessManager.startPaymentBatch(payments, request.behavior());
 
         return batchId;
     }


### PR DESCRIPTION
## Summary

Add batch operations for starting multiple processes at once, dramatically improving performance for high-volume payment batch scenarios.

**Before:** 10,000 payments in ~128 seconds (~78 payments/sec)
**After:** Expected 8-12x improvement (~10-15 seconds)

## Changes

### Framework Changes (Core Library)
- **JdbcProcessRepository**: Add `saveBatch()` and `logBatchSteps()` methods for batch inserting processes and audit entries
- **BaseProcessManager**: Add `startBatch()` method that uses batch inserts and `CommandBus.sendBatch()` for efficient multi-process startup

### E2E Test Application Changes
- **PaymentProcessManager**: Add `startPaymentBatch()` helper method
- **E2EService**: Update `createPaymentBatch()` to use batch operations
- **E2ETestApplication**: Increase reply router concurrency from 2 to 20

## Performance Impact

The batch operations reduce ~50,000 sequential DB operations to:
- 1 batch INSERT for processes
- 1 batch PGMQ send for commands  
- 1 batch INSERT for audit entries

| Optimization | Before | After |
|--------------|--------|-------|
| Reply concurrency | 2 | 20 |
| Process inserts | 10,000 individual | 1 batch |
| Command sends | 10,000 individual | 1 batch |

## Test plan

- [x] All 501 existing tests pass
- [ ] Manual test: Create 10,000 payment batch and verify < 20 second completion
- [ ] Verify reply processing handles increased throughput

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)