### PR TITLE
feat: add PaymentCommandStepProcess with command step execution model

### DIFF
--- a/src/test/java/com/ivamare/commandbus/e2e/E2ETestApplication.java
+++ b/src/test/java/com/ivamare/commandbus/e2e/E2ETestApplication.java
@@ -13,6 +13,7 @@ import com.ivamare.commandbus.pgmq.PgmqClient;
 import com.ivamare.commandbus.process.BaseProcessManager;
 import com.ivamare.commandbus.process.ProcessReplyRouter;
 import com.ivamare.commandbus.process.ProcessRepository;
+import com.ivamare.commandbus.process.step.CommandStepResponseHandler;
 import com.ivamare.commandbus.process.step.ProcessStepWorker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.sql.DataSource;
 import java.util.List;
@@ -191,6 +194,41 @@ public class E2ETestApplication {
             worker.start();
         } catch (Exception e) {
             log.debug("ProcessStepWorker not available (UI-only mode): {}", e.getMessage());
+        }
+    }
+
+    // ========== CommandStep Reply Handling ==========
+
+    /**
+     * Create CommandStepResponseHandler to poll payments__replies and route
+     * responses back to PaymentCommandStepProcess.
+     * Only runs in worker mode (not UI).
+     */
+    @Bean
+    @Profile("!ui")
+    public CommandStepResponseHandler commandStepResponseHandler(
+            PgmqClient pgmqClient,
+            ObjectMapper objectMapper,
+            PaymentCommandStepProcess paymentCommandStepProcess) {
+        log.info("Creating CommandStepResponseHandler for payments__replies");
+        return new CommandStepResponseHandler(
+            pgmqClient,
+            objectMapper,
+            List.of(paymentCommandStepProcess)
+        );
+    }
+
+    /**
+     * Auto-start the CommandStepResponseHandler when the application is ready.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void startCommandStepResponseHandler(ApplicationReadyEvent event) {
+        try {
+            CommandStepResponseHandler handler = event.getApplicationContext().getBean(CommandStepResponseHandler.class);
+            log.info("Auto-starting CommandStepResponseHandler");
+            handler.start();
+        } catch (Exception e) {
+            log.debug("CommandStepResponseHandler not available (UI-only mode): {}", e.getMessage());
         }
     }
 }

--- a/src/test/java/com/ivamare/commandbus/e2e/dto/PaymentBatchCreateRequest.java
+++ b/src/test/java/com/ivamare/commandbus/e2e/dto/PaymentBatchCreateRequest.java
@@ -11,7 +11,9 @@ import java.time.LocalDate;
 /**
  * Request DTO for creating a batch of payments.
  *
- * @param executionModel Execution model: "COMMAND_BASED" (BaseProcessManager) or "STEP_BASED" (ProcessStepManager)
+ * @param executionModel Execution model: "COMMAND_BASED" (BaseProcessManager),
+ *                       "STEP_BASED" (ProcessStepManager), or
+ *                       "COMMAND_STEP" (ProcessStepManager with commandStep() for external calls)
  */
 public record PaymentBatchCreateRequest(
     String name,
@@ -48,6 +50,21 @@ public record PaymentBatchCreateRequest(
      */
     public boolean isStepBasedModel() {
         return "STEP_BASED".equals(executionModel);
+    }
+
+    /**
+     * Check if using COMMAND_STEP execution model (ProcessStepManager with commandStep()).
+     */
+    public boolean isCommandStepModel() {
+        return "COMMAND_STEP".equals(executionModel);
+    }
+
+    /**
+     * Check if using process-step based execution (either STEP_BASED or COMMAND_STEP).
+     * Both use PaymentStepState and ProcessStepManager infrastructure.
+     */
+    public boolean isProcessStepBasedModel() {
+        return isStepBasedModel() || isCommandStepModel();
     }
 
     /**

--- a/src/test/java/com/ivamare/commandbus/e2e/handlers/PaymentProcessHandlers.java
+++ b/src/test/java/com/ivamare/commandbus/e2e/handlers/PaymentProcessHandlers.java
@@ -1,0 +1,100 @@
+package com.ivamare.commandbus.e2e.handlers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ivamare.commandbus.handler.HandlerRegistry;
+import com.ivamare.commandbus.model.Command;
+import com.ivamare.commandbus.model.HandlerContext;
+import com.ivamare.commandbus.pgmq.PgmqClient;
+import com.ivamare.commandbus.e2e.commands.fx.BookFxHandler;
+import com.ivamare.commandbus.e2e.commands.network.SubmitPaymentHandler;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * Command handlers for the payment_process domain.
+ *
+ * <p>This domain handles external service calls from PaymentCommandStepProcess:
+ * <ul>
+ *   <li>BookFx - FX booking simulation</li>
+ *   <li>SubmitPayment - Payment network submission simulation</li>
+ * </ul>
+ *
+ * <p>Using a common domain for both command types simplifies the E2E setup
+ * by requiring only one worker instead of separate fx and network workers.
+ *
+ * <p>Only active when running with the 'worker' profile (not 'ui' only mode).
+ */
+@Component
+@Profile("!ui")
+public class PaymentProcessHandlers {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentProcessHandlers.class);
+    private static final String DOMAIN = "payment_process";
+
+    private final HandlerRegistry handlerRegistry;
+    private final PgmqClient pgmqClient;
+    private final ObjectMapper objectMapper;
+
+    // Delegate handlers for actual processing
+    private final BookFxHandler bookFxHandler;
+    private final SubmitPaymentHandler submitPaymentHandler;
+
+    public PaymentProcessHandlers(
+            HandlerRegistry handlerRegistry,
+            PgmqClient pgmqClient,
+            ObjectMapper objectMapper) {
+        this.handlerRegistry = handlerRegistry;
+        this.pgmqClient = pgmqClient;
+        this.objectMapper = objectMapper;
+        this.bookFxHandler = new BookFxHandler(objectMapper);
+        this.submitPaymentHandler = new SubmitPaymentHandler(objectMapper);
+    }
+
+    @PostConstruct
+    public void initialize() {
+        // Create the queue if it doesn't exist
+        createQueueIfNotExists();
+
+        // Register handlers for both command types in the payment_process domain
+        handlerRegistry.register(DOMAIN, "BookFx", this::handleBookFx);
+        handlerRegistry.register(DOMAIN, "SubmitPayment", this::handleSubmitPayment);
+
+        log.info("Registered payment_process domain handlers: BookFx, SubmitPayment");
+    }
+
+    private void createQueueIfNotExists() {
+        String queueName = DOMAIN + "__commands";
+        try {
+            pgmqClient.createQueue(queueName);
+            log.info("Created queue: {}", queueName);
+        } catch (Exception e) {
+            // Queue might already exist, which is fine
+            if (e.getMessage() != null && e.getMessage().contains("already exists")) {
+                log.debug("Queue {} already exists", queueName);
+            } else {
+                log.warn("Error creating queue {}: {}", queueName, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Handle BookFx command - delegates to BookFxHandler.
+     */
+    public Map<String, Object> handleBookFx(Command command, HandlerContext context) {
+        log.info("Processing BookFx in payment_process domain: {}", command.commandId());
+        return bookFxHandler.handleBookFx(command, context);
+    }
+
+    /**
+     * Handle SubmitPayment command - delegates to SubmitPaymentHandler.
+     */
+    public Map<String, Object> handleSubmitPayment(Command command, HandlerContext context) {
+        log.info("Processing SubmitPayment in payment_process domain: {}", command.commandId());
+        return submitPaymentHandler.handleSubmitPayment(command, context);
+    }
+}

--- a/src/test/java/com/ivamare/commandbus/e2e/payment/step/PaymentCommandStepProcess.java
+++ b/src/test/java/com/ivamare/commandbus/e2e/payment/step/PaymentCommandStepProcess.java
@@ -1,0 +1,567 @@
+package com.ivamare.commandbus.e2e.payment.step;
+
+import com.ivamare.commandbus.CommandBusProperties;
+import com.ivamare.commandbus.api.CommandBus;
+import com.ivamare.commandbus.e2e.payment.*;
+import com.ivamare.commandbus.process.ProcessRepository;
+import com.ivamare.commandbus.process.step.DeadlineAction;
+import com.ivamare.commandbus.process.step.ExceptionType;
+import com.ivamare.commandbus.process.step.StepOptions;
+import com.ivamare.commandbus.process.step.TestProcessStepManager;
+import com.ivamare.commandbus.process.step.exceptions.StepBusinessRuleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Payment processing workflow using commandStep() for external service calls.
+ *
+ * <p>This is an alternative implementation to PaymentStepProcess that demonstrates
+ * the commandStep() pattern for calling external domains (FX service, Payment network)
+ * via PGMQ queues, providing natural rate limiting through queue concurrency control.
+ *
+ * <p>Workflow:
+ * <pre>{@code
+ * execute(state):
+ *     step("updateStatusProcessing")  // Local step
+ *     step("bookRisk")                 // Local step with risk assessment
+ *     commandStep("bookFx")            // External call to FX domain via PGMQ
+ *     commandStep("submitPayment")     // External call to network domain via PGMQ
+ *     wait("awaitL4")                  // Wait for L4 settlement confirmation
+ * }</pre>
+ *
+ * <p>The key difference from PaymentStepProcess is that bookFx and submitPayment
+ * are executed as commands sent to external domain workers, rather than local
+ * simulations. This provides:
+ * <ul>
+ *   <li>Natural rate limiting via worker concurrency (replicas × concurrent-messages)</li>
+ *   <li>Decoupled execution - external services run independently</li>
+ *   <li>True async response handling via reply queues</li>
+ * </ul>
+ *
+ * <p>Configuration required in application.yml:
+ * <pre>
+ * commandbus:
+ *   command-steps:
+ *     bookFx:
+ *       domain: fx
+ *       command-type: BookFx
+ *       timeout: 30s
+ *     submitPayment:
+ *       domain: network
+ *       command-type: SubmitPayment
+ *       timeout: 60s
+ * </pre>
+ */
+public class PaymentCommandStepProcess extends TestProcessStepManager<PaymentStepState> {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentCommandStepProcess.class);
+
+    private static final String DOMAIN = "payments";
+    private static final String PROCESS_TYPE = "PAYMENT_COMMAND_STEP";
+
+    private final Random random = new Random();
+    private final PaymentRepository paymentRepository;
+    private final PendingApprovalRepository pendingApprovalRepository;
+
+    // Network simulator for async L1-L4 responses
+    private StepPaymentNetworkSimulator networkSimulator;
+
+    public PaymentCommandStepProcess(
+            ProcessRepository processRepo,
+            JdbcTemplate jdbcTemplate,
+            TransactionTemplate transactionTemplate,
+            CommandBus commandBus,
+            CommandBusProperties properties,
+            PaymentRepository paymentRepository,
+            PendingApprovalRepository pendingApprovalRepository) {
+        super(processRepo, jdbcTemplate, transactionTemplate, commandBus, properties);
+        this.paymentRepository = paymentRepository;
+        this.pendingApprovalRepository = pendingApprovalRepository;
+    }
+
+    public void setNetworkSimulator(StepPaymentNetworkSimulator networkSimulator) {
+        this.networkSimulator = networkSimulator;
+    }
+
+    @Override
+    public String getProcessType() {
+        return PROCESS_TYPE;
+    }
+
+    @Override
+    public String getDomain() {
+        return DOMAIN;
+    }
+
+    @Override
+    public Class<PaymentStepState> getStateClass() {
+        return PaymentStepState.class;
+    }
+
+    @Override
+    protected Duration getDefaultWaitTimeout() {
+        return Duration.ofHours(4);
+    }
+
+    @Override
+    protected DeadlineAction getDeadlineAction() {
+        return DeadlineAction.TSQ;
+    }
+
+    @Override
+    protected ExceptionType classifyException(Exception e) {
+        if (e instanceof StepBusinessRuleException) {
+            return ExceptionType.BUSINESS;
+        }
+        if (e.getMessage() != null && (
+            e.getMessage().contains("timeout") ||
+            e.getMessage().contains("connection") ||
+            e.getMessage().contains("temporarily"))) {
+            return ExceptionType.TRANSIENT;
+        }
+        return ExceptionType.PERMANENT;
+    }
+
+    // ========== Workflow Execution ==========
+
+    @Override
+    protected void execute(PaymentStepState state) {
+        // Step 1: Update payment status to PROCESSING
+        step("updateStatusProcessing", StepOptions.<PaymentStepState, Void>builder()
+            .action(this::updateStatusToProcessing)
+            .compensation(this::updateStatusToCancelled)
+            .build());
+
+        // Step 2: Book risk (local step with risk assessment)
+        step("bookRisk", StepOptions.<PaymentStepState, String>builder()
+            .action(this::executeBookRisk)
+            .maxRetries(3)
+            .retryDelay(Duration.ofSeconds(1))
+            .compensation(this::releaseRiskBooking)
+            .build());
+
+        // Wait for risk approval if decision was PENDING
+        if (state.isRiskPending() || state.findWait("awaitRiskApproval").isPresent()) {
+            log.info("Risk decision PENDING for payment {} - waiting for manual approval", state.getPaymentId());
+            wait("awaitRiskApproval", state::isRiskResolved, Duration.ofSeconds(30));
+        }
+
+        // Check for DECLINED risk
+        if ("DECLINED".equals(state.getRiskDecision())) {
+            log.info("Risk DECLINED for payment {} - triggering compensation", state.getPaymentId());
+            throw new StepBusinessRuleException("Risk declined for payment " + state.getPaymentId());
+        }
+
+        // Step 3: Book FX via commandStep() - sends command to FX domain
+        if (shouldBookFx(state)) {
+            Payment payment = loadPayment(state.getPaymentId());
+            FxResponse fxResponse = commandStep("bookFx",
+                FxRequest.from(payment, state),
+                FxResponse.class,
+                this::releaseFxBooking);
+
+            // Update state with FX response
+            state.setFxContractId(fxResponse.contractId());
+            state.setFxRate(fxResponse.rate());
+            state.setCreditAmount(fxResponse.convertedAmount());
+            log.info("FX booked for payment {}: contract={}, rate={}",
+                state.getPaymentId(), fxResponse.contractId(), fxResponse.rate());
+        }
+
+        // Step 4: Submit payment via commandStep() - sends command to network domain
+        Payment paymentForSubmit = loadPayment(state.getPaymentId());
+        SubmitPaymentResponse submitResponse = commandStep("submitPayment",
+            SubmitPaymentRequest.from(paymentForSubmit, state),
+            SubmitPaymentResponse.class);
+
+        // Update state with submission response
+        state.setSubmissionReference(submitResponse.submissionReference());
+        state.setSubmissionCommandId(submitResponse.commandId());
+        log.info("Payment {} submitted to network with ref {}",
+            state.getPaymentId(), submitResponse.submissionReference());
+
+        // Trigger network simulator for L1-L4 confirmations (if configured)
+        if (networkSimulator != null) {
+            UUID processId = getCurrentProcessId();
+            log.info("Triggering network simulator for process {} (payment {})",
+                processId, state.getPaymentId());
+            networkSimulator.simulatePaymentConfirmations(
+                submitResponse.commandId(),
+                processId,
+                state.getBehavior()
+            );
+        }
+
+        // Step 5: Wait for L4 confirmation (final settlement)
+        wait("awaitL4", () -> state.getL4CompletedAt() != null, Duration.ofSeconds(30));
+        if (state.getL4ErrorCode() != null) {
+            throw new StepBusinessRuleException("L4 failed: " + state.getL4ErrorCode());
+        }
+
+        log.info("Payment {} completed successfully with L4 confirmation", state.getPaymentId());
+    }
+
+    // ========== Local Step Implementations ==========
+
+    private Void updateStatusToProcessing(PaymentStepState state) {
+        updatePaymentStatus(state.getPaymentId(), PaymentStatus.PROCESSING);
+        return null;
+    }
+
+    private void updateStatusToCancelled(PaymentStepState state) {
+        updatePaymentStatus(state.getPaymentId(), PaymentStatus.CANCELLED);
+    }
+
+    private String executeBookRisk(PaymentStepState state) {
+        RiskBehavior riskBehavior = state.getBehavior() != null
+            ? state.getBehavior().bookRisk()
+            : RiskBehavior.defaults();
+
+        double roll = random.nextDouble() * 100;
+        RiskBehavior.RiskAssessmentResult result = riskBehavior.assess(roll);
+
+        state.setRiskType(result.type().name());
+        state.setRiskDecision(result.decision().name());
+
+        log.info("Risk assessment for payment {}: type={}, decision={}",
+            state.getPaymentId(), result.type(), result.decision());
+
+        if (result.isDeclined()) {
+            throw new StepBusinessRuleException(
+                "Risk assessment declined for payment " + state.getPaymentId());
+        }
+
+        if (result.isPending()) {
+            createPendingApproval(state);
+        }
+
+        String riskRef = "RISK-" + UUID.randomUUID().toString().substring(0, 8);
+        state.setRiskReference(riskRef);
+        log.info("Risk booking completed for payment {} with ref {}", state.getPaymentId(), riskRef);
+        return riskRef;
+    }
+
+    private void releaseRiskBooking(PaymentStepState state) {
+        log.info("Releasing risk booking {} for payment {}", state.getRiskReference(), state.getPaymentId());
+    }
+
+    private boolean shouldBookFx(PaymentStepState state) {
+        return state.isFxRequired();
+    }
+
+    private void releaseFxBooking(PaymentStepState state) {
+        log.info("Releasing FX contract {} for payment {}", state.getFxContractId(), state.getPaymentId());
+    }
+
+    private UUID getCurrentProcessId() {
+        return currentContext.get().processId();
+    }
+
+    private Payment loadPayment(UUID paymentId) {
+        return paymentRepository.findById(paymentId, jdbcTemplate)
+            .orElseThrow(() -> new IllegalStateException("Payment not found: " + paymentId));
+    }
+
+    private void updatePaymentStatus(UUID paymentId, PaymentStatus status) {
+        log.debug("Updating payment {} status to {}", paymentId, status);
+        paymentRepository.updateStatus(paymentId, status, jdbcTemplate);
+        log.info("Payment {} status updated to {}", paymentId, status);
+    }
+
+    private void createPendingApproval(PaymentStepState state) {
+        UUID processId = getCurrentProcessId();
+        UUID paymentId = state.getPaymentId();
+
+        Payment payment = paymentRepository.findById(paymentId, jdbcTemplate)
+            .orElseThrow(() -> new IllegalStateException("Payment not found: " + paymentId));
+
+        PendingApproval approval = PendingApproval.create(
+            paymentId,
+            processId,
+            processId,
+            UUID.randomUUID(),
+            payment.debitAmount(),
+            payment.debitCurrency().name(),
+            payment.debitAccount().transit() + "-" + payment.debitAccount().accountNumber(),
+            payment.creditAccount().bic() + "/" + payment.creditAccount().iban(),
+            "COMMAND_STEP"
+        );
+
+        pendingApprovalRepository.save(approval);
+        log.info("Created pending approval {} for payment {} (process {})",
+            approval.id(), paymentId, processId);
+    }
+
+    // ========== Async Response Resolution (for L1-L4) ==========
+
+    public void resolveRiskApproval(UUID processId, boolean approved) {
+        log.info("Resolving risk approval for process {}: approved={}", processId, approved);
+
+        pendingApprovalRepository.findByProcessId(processId).ifPresent(approval -> {
+            PendingApproval.ApprovalStatus status = approved
+                ? PendingApproval.ApprovalStatus.APPROVED
+                : PendingApproval.ApprovalStatus.REJECTED;
+            PendingApproval resolved = approval.withResolution(status, "system", null);
+            pendingApprovalRepository.update(resolved);
+        });
+
+        processAsyncResponse(processId, state -> {
+            if (approved) {
+                state.setRiskDecision("APPROVED");
+                state.setRiskApprovedAt(Instant.now());
+            } else {
+                state.setRiskDecision("DECLINED");
+            }
+        });
+    }
+
+    public void confirmL1(UUID processId, String reference) {
+        updatePaymentL(processId, 1, reference, null, null);
+        processAsyncResponse(processId, state -> state.recordL1Success(reference));
+    }
+
+    public void failL1(UUID processId, String errorCode, String errorMessage) {
+        processAsyncResponse(processId, state -> state.recordL1Error(errorCode, errorMessage));
+    }
+
+    public void confirmL2(UUID processId, String reference) {
+        updatePaymentL(processId, 2, reference, null, null);
+        processAsyncResponse(processId, state -> state.recordL2Success(reference));
+    }
+
+    public void failL2(UUID processId, String errorCode, String errorMessage) {
+        processAsyncResponse(processId, state -> state.recordL2Error(errorCode, errorMessage));
+    }
+
+    public void confirmL3(UUID processId, String reference) {
+        updatePaymentL(processId, 3, reference, null, null);
+        processAsyncResponse(processId, state -> state.recordL3Success(reference));
+    }
+
+    public void failL3(UUID processId, String errorCode, String errorMessage) {
+        processAsyncResponse(processId, state -> state.recordL3Error(errorCode, errorMessage));
+    }
+
+    public void confirmL4(UUID processId, String reference) {
+        updatePaymentL(processId, 4, reference, PaymentStatus.COMPLETE, null);
+        processAsyncResponse(processId, state -> state.recordL4Success(reference));
+    }
+
+    public void failL4(UUID processId, String errorCode, String errorMessage) {
+        processAsyncResponse(processId, state -> state.recordL4Error(errorCode, errorMessage));
+    }
+
+    private void updatePaymentL(UUID processId, int level, String reference,
+                                 PaymentStatus newStatus, Instant receivedAt) {
+        UUID paymentId = getPaymentIdFromProcess(processId);
+        if (paymentId == null) return;
+
+        Instant ts = receivedAt != null ? receivedAt : Instant.now();
+        if (newStatus != null) {
+            paymentRepository.updateNetworkConfirmationAndStatus(
+                paymentId, level, reference, ts, newStatus, jdbcTemplate);
+        } else {
+            paymentRepository.updateNetworkConfirmation(paymentId, level, reference, ts, jdbcTemplate);
+        }
+        log.info("Updated Payment {} with L{} confirmation (ref={})", paymentId, level, reference);
+    }
+
+    private UUID getPaymentIdFromProcess(UUID processId) {
+        try {
+            return processRepo.getById(getDomain(), processId, jdbcTemplate)
+                .map(process -> {
+                    Object state = process.state();
+                    if (state instanceof PaymentStepState paymentState) {
+                        return paymentState.getPaymentId();
+                    }
+                    return null;
+                })
+                .orElse(null);
+        } catch (Exception e) {
+            log.warn("Failed to get paymentId from process {}: {}", processId, e.getMessage());
+            return null;
+        }
+    }
+
+    // ========== TSQ Callbacks ==========
+
+    @Override
+    protected void onProcessCanceled(UUID processId, PaymentStepState state) {
+        if (state.getPaymentId() != null) {
+            log.info("TSQ cancel: updating payment {} to CANCELLED", state.getPaymentId());
+            updatePaymentStatus(state.getPaymentId(), PaymentStatus.CANCELLED);
+        }
+    }
+
+    @Override
+    protected void onProcessCompleted(UUID processId, PaymentStepState state) {
+        if (state.getPaymentId() != null) {
+            log.info("TSQ complete: updating payment {} to COMPLETE", state.getPaymentId());
+            updatePaymentStatus(state.getPaymentId(), PaymentStatus.COMPLETE);
+        }
+    }
+
+    // ========== Inner Classes for Command Step Request/Response ==========
+
+    /**
+     * Request sent to FX domain via commandStep("bookFx").
+     */
+    public record FxRequest(
+        String sourceCurrency,
+        String targetCurrency,
+        BigDecimal amount,
+        String paymentId,
+        String expectedOutcome
+    ) {
+        public static FxRequest from(Payment payment, PaymentStepState state) {
+            String expectedOutcome = null;
+            if (state.getBehavior() != null && state.getBehavior().bookFx() != null) {
+                // Map behavior to expected outcome for handler
+                var behavior = state.getBehavior().bookFx();
+                expectedOutcome = determineExpectedOutcome(behavior);
+            }
+            return new FxRequest(
+                payment.debitCurrency().name(),
+                payment.creditCurrency().name(),
+                payment.debitAmount(),
+                payment.paymentId() != null ? payment.paymentId().toString() : null,
+                expectedOutcome
+            );
+        }
+
+        private static String determineExpectedOutcome(
+                com.ivamare.commandbus.e2e.process.ProbabilisticBehavior behavior) {
+            if (behavior == null) return "SUCCESS";
+            Random r = new Random();
+            double roll = r.nextDouble() * 100;
+            if (roll < behavior.failPermanentPct()) return "PERMANENT_FAILURE";
+            roll -= behavior.failPermanentPct();
+            if (roll < behavior.failTransientPct()) return "TRANSIENT_FAILURE";
+            roll -= behavior.failTransientPct();
+            if (roll < behavior.failBusinessRulePct()) return "BUSINESS_ERROR";
+            roll -= behavior.failBusinessRulePct();
+            if (roll < behavior.timeoutPct()) return "TIMEOUT";
+            return "SUCCESS";
+        }
+
+        public Map<String, Object> toMap() {
+            return Map.of(
+                "sourceCurrency", sourceCurrency != null ? sourceCurrency : "USD",
+                "targetCurrency", targetCurrency != null ? targetCurrency : "EUR",
+                "amount", amount != null ? amount : BigDecimal.ZERO,
+                "paymentId", paymentId != null ? paymentId : "",
+                "expectedOutcome", expectedOutcome != null ? expectedOutcome : "SUCCESS"
+            );
+        }
+    }
+
+    /**
+     * Response from FX domain.
+     */
+    public record FxResponse(
+        Long contractId,
+        BigDecimal rate,
+        BigDecimal convertedAmount,
+        String sourceCurrency,
+        String targetCurrency
+    ) {
+        @SuppressWarnings("unchecked")
+        public static FxResponse fromMap(Map<String, Object> map) {
+            return new FxResponse(
+                map.get("contractId") instanceof Number n ? n.longValue() : null,
+                parseDecimal(map.get("rate")),
+                parseDecimal(map.get("convertedAmount")),
+                (String) map.get("sourceCurrency"),
+                (String) map.get("targetCurrency")
+            );
+        }
+
+        private static BigDecimal parseDecimal(Object value) {
+            if (value == null) return null;
+            if (value instanceof BigDecimal bd) return bd;
+            if (value instanceof Number n) return BigDecimal.valueOf(n.doubleValue());
+            if (value instanceof String s) return new BigDecimal(s);
+            return null;
+        }
+    }
+
+    /**
+     * Request sent to network domain via commandStep("submitPayment").
+     */
+    public record SubmitPaymentRequest(
+        String paymentId,
+        String submissionReference,
+        BigDecimal amount,
+        String currency,
+        String expectedOutcome
+    ) {
+        public static SubmitPaymentRequest from(Payment payment, PaymentStepState state) {
+            String expectedOutcome = null;
+            if (state.getBehavior() != null && state.getBehavior().submitPayment() != null) {
+                var behavior = state.getBehavior().submitPayment();
+                expectedOutcome = determineExpectedOutcome(behavior);
+            }
+            return new SubmitPaymentRequest(
+                payment.paymentId() != null ? payment.paymentId().toString() : null,
+                state.getSubmissionReference(),
+                payment.debitAmount(),
+                payment.debitCurrency().name(),
+                expectedOutcome
+            );
+        }
+
+        private static String determineExpectedOutcome(
+                com.ivamare.commandbus.e2e.process.ProbabilisticBehavior behavior) {
+            if (behavior == null) return "SUCCESS";
+            Random r = new Random();
+            double roll = r.nextDouble() * 100;
+            if (roll < behavior.failPermanentPct()) return "PERMANENT_FAILURE";
+            roll -= behavior.failPermanentPct();
+            if (roll < behavior.failTransientPct()) return "TRANSIENT_FAILURE";
+            roll -= behavior.failTransientPct();
+            if (roll < behavior.failBusinessRulePct()) return "BUSINESS_ERROR";
+            roll -= behavior.failBusinessRulePct();
+            if (roll < behavior.timeoutPct()) return "TIMEOUT";
+            return "SUCCESS";
+        }
+
+        public Map<String, Object> toMap() {
+            return Map.of(
+                "paymentId", paymentId != null ? paymentId : "",
+                "submissionReference", submissionReference != null ? submissionReference : "",
+                "amount", amount != null ? amount : BigDecimal.ZERO,
+                "currency", currency != null ? currency : "USD",
+                "expectedOutcome", expectedOutcome != null ? expectedOutcome : "SUCCESS"
+            );
+        }
+    }
+
+    /**
+     * Response from network domain.
+     */
+    public record SubmitPaymentResponse(
+        String submissionReference,
+        UUID commandId,
+        String status,
+        Instant submittedAt
+    ) {
+        @SuppressWarnings("unchecked")
+        public static SubmitPaymentResponse fromMap(Map<String, Object> map) {
+            return new SubmitPaymentResponse(
+                (String) map.get("submissionReference"),
+                map.get("commandId") != null ? UUID.fromString((String) map.get("commandId")) : null,
+                (String) map.get("status"),
+                map.get("submittedAt") != null ? Instant.parse((String) map.get("submittedAt")) : null
+            );
+        }
+    }
+}

--- a/src/test/resources/application-e2e.yml
+++ b/src/test/resources/application-e2e.yml
@@ -49,13 +49,14 @@ commandbus:
     deadline-check-interval-ms: 60000  # Check process deadlines
     auto-start: true
   # Command step configuration for COMMAND_STEP execution model
+  # Uses a common payment_process domain to avoid creating separate fx/network workers
   command-steps:
     bookFx:
-      domain: fx
+      domain: payment_process
       command-type: BookFx
       timeout: 30s
     submitPayment:
-      domain: network
+      domain: payment_process
       command-type: SubmitPayment
       timeout: 60s
 

--- a/src/test/resources/application-e2e.yml
+++ b/src/test/resources/application-e2e.yml
@@ -48,6 +48,16 @@ commandbus:
     timeout-check-interval-ms: 60000   # Check wait timeouts
     deadline-check-interval-ms: 60000  # Check process deadlines
     auto-start: true
+  # Command step configuration for COMMAND_STEP execution model
+  command-steps:
+    bookFx:
+      domain: fx
+      command-type: BookFx
+      timeout: 30s
+    submitPayment:
+      domain: network
+      command-type: SubmitPayment
+      timeout: 60s
 
 server:
   port: 8080

--- a/src/test/resources/templates/e2e/layout/main.html
+++ b/src/test/resources/templates/e2e/layout/main.html
@@ -5,10 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title th:replace="${title}">E2E Test App</title>
-    <link rel="stylesheet" th:href="@{/webjars/bootstrap/5.3.2/css/bootstrap.min.css}">
-    <link rel="stylesheet" th:href="@{/webjars/bootstrap-icons/1.11.1/font/bootstrap-icons.css}">
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap/5.3.8/css/bootstrap.min.css}">
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap-icons/1.13.1/font/bootstrap-icons.css}">
     <link rel="stylesheet" th:href="@{/css/e2e.css}">
-    <script th:src="@{/webjars/htmx.org/1.9.10/dist/htmx.min.js}"></script>
+    <script th:src="@{/webjars/htmx.org/2.0.8/dist/htmx.min.js}"></script>
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -118,6 +118,6 @@
         </div>
     </div>
 
-    <script th:src="@{/webjars/bootstrap/5.3.2/js/bootstrap.bundle.min.js}"></script>
+    <script th:src="@{/webjars/bootstrap/5.3.8/js/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/test/resources/templates/e2e/pages/payment_batch_new.html
+++ b/src/test/resources/templates/e2e/pages/payment_batch_new.html
@@ -64,6 +64,9 @@
                             <option value="STEP_BASED" th:selected="${request.executionModel() == 'STEP_BASED'}">
                                 STEP_BASED
                             </option>
+                            <option value="COMMAND_STEP" th:selected="${request.executionModel() == 'COMMAND_STEP'}">
+                                COMMAND_STEP
+                            </option>
                         </select>
                         <small class="text-muted">Workflow execution approach</small>
                     </div>

--- a/src/test/resources/templates/e2e/pages/payment_new.html
+++ b/src/test/resources/templates/e2e/pages/payment_new.html
@@ -108,6 +108,9 @@
                             <option value="STEP_BASED" th:selected="${request.executionModel() == 'STEP_BASED'}">
                                 STEP_BASED
                             </option>
+                            <option value="COMMAND_STEP" th:selected="${request.executionModel() == 'COMMAND_STEP'}">
+                                COMMAND_STEP
+                            </option>
                         </select>
                         <small class="text-muted">Workflow execution approach</small>
                     </div>


### PR DESCRIPTION
## Summary
- Add `PaymentCommandStepProcess` that uses `commandStep()` for `bookFx` and `submitPayment` steps
- Commands are sent to `payment_process` domain via PGMQ queues for natural rate limiting
- Add `CommandStepResponseHandler` to poll `payments__replies` and route responses back to processes
- Add `PaymentProcessHandlers` to handle `BookFx` and `SubmitPayment` commands in `payment_process` domain
- Add COMMAND_STEP option to E2E UI dropdowns for execution model selection

## Test plan
- [x] Verify COMMAND_STEP option appears in payment batch creation form
- [x] Create a payment with COMMAND_STEP execution model
- [x] Verify payment progresses through bookFx and submitPayment steps
- [x] Verify audit trail shows COMMAND_STEP_SENT, ASYNC_RESPONSE, and STEP_EXECUTE entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)